### PR TITLE
refactor: タスク自動実行トリガーの改善とCI設定の最適化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,16 @@ name: CI
 on:
   push:
     branches: [main, develop]
+    paths-ignore:
+      - '.cursor/**'
+      - '*.md'
+      - 'docs/**'
   pull_request:
     branches: [main, develop]
+    paths-ignore:
+      - '.cursor/**'
+      - '*.md'
+      - 'docs/**'
 
 jobs:
   lint:

--- a/.gitignore
+++ b/.gitignore
@@ -22,10 +22,6 @@ data/*/*
 # IDE
 .idea/
 
-# Cursor AI settings (keep rules, ignore temporary files if any)
-# .cursor/rules/ は共有すべきルールファイルのため、Gitで管理する
-# 将来的にCIを追加する場合は、lintやtestの対象から除外すること
-
 # Logs
 logs/
 *.log


### PR DESCRIPTION
## 概要

タスク自動実行トリガーのコマンドを改善し、CI設定を最適化しました。

## 変更内容

### 1. タスク自動実行トリガーの改善
- トリガーワードを「よろしこ」から `/start-task` コマンドに変更
- AIアシスタントへの必須ルールとして明確化
- 自動実行手順をより詳細に記述
- コマンド形式にすることでトリガーの認識を改善

### 2. CI設定の最適化
- GitHub Actions CI で `.cursor/**` ディレクトリを除外
- `*.md`, `docs/**` のドキュメントファイルも除外対象に追加
- AIの設定ファイルやドキュメント変更時にCIが不要に実行されることを防止

## 関連Issue

なし（内部改善）

## テスト

- [ ] `/start-task` コマンドが正しく動作することを確認
- [x] CI設定ファイルの構文が正しいことを確認

## チェックリスト

- [x] コミットメッセージが規約に従っている
- [x] 変更内容が適切にドキュメント化されている
- [x] 不要なファイルは含まれていない


---
Related to #10 #146
