### PR TITLE
fix: E2EテストにHttpExceptionFilterを追加 (#222)

### DIFF
--- a/apps/backend/test/app.e2e-spec.ts
+++ b/apps/backend/test/app.e2e-spec.ts
@@ -3,6 +3,7 @@ import { INestApplication } from '@nestjs/common';
 import request from 'supertest';
 import { AppModule } from './../src/app.module';
 import { E2ETestDatabaseHelper } from './helpers/database-helper';
+import { HttpExceptionFilter } from '../src/common/filters/http-exception.filter';
 
 describe('AppController (e2e)', () => {
   let app: INestApplication;
@@ -14,6 +15,7 @@ describe('AppController (e2e)', () => {
     }).compile();
 
     app = moduleFixture.createNestApplication();
+    app.useGlobalFilters(new HttpExceptionFilter());
     await app.init();
 
     // データベースヘルパーの初期化

--- a/apps/backend/test/health.e2e-spec.ts
+++ b/apps/backend/test/health.e2e-spec.ts
@@ -5,6 +5,7 @@ import { AppModule } from '../src/app.module';
 import { promises as fs } from 'fs';
 import { join } from 'path';
 import { E2ETestDatabaseHelper } from './helpers/database-helper';
+import { HttpExceptionFilter } from '../src/common/filters/http-exception.filter';
 
 describe('HealthController (e2e)', () => {
   let app: INestApplication;
@@ -18,6 +19,7 @@ describe('HealthController (e2e)', () => {
     }).compile();
 
     app = moduleFixture.createNestApplication();
+    app.useGlobalFilters(new HttpExceptionFilter());
     app.useGlobalPipes(
       new ValidationPipe({
         transform: true,

--- a/apps/backend/test/institution.e2e-spec.ts
+++ b/apps/backend/test/institution.e2e-spec.ts
@@ -5,6 +5,7 @@ import { AppModule } from '../src/app.module';
 import { InstitutionType, BankCategory } from '@account-book/types';
 import type { ErrorDetail } from '@account-book/types';
 import { E2ETestDatabaseHelper } from './helpers/database-helper';
+import { HttpExceptionFilter } from '../src/common/filters/http-exception.filter';
 
 describe('Institution Controller (e2e)', () => {
   let app: INestApplication;
@@ -16,6 +17,9 @@ describe('Institution Controller (e2e)', () => {
     }).compile();
 
     app = moduleFixture.createNestApplication();
+
+    // Global filters
+    app.useGlobalFilters(new HttpExceptionFilter());
 
     // Global pipes
     app.useGlobalPipes(

--- a/apps/backend/test/securities.e2e-spec.ts
+++ b/apps/backend/test/securities.e2e-spec.ts
@@ -5,6 +5,7 @@ import { SecuritiesModule } from '../src/modules/securities/securities.module';
 import { ConfigModule } from '@nestjs/config';
 import appConfig from '../src/config/app.config';
 import cryptoConfig from '../src/config/crypto.config';
+import { HttpExceptionFilter } from '../src/common/filters/http-exception.filter';
 
 describe('Securities API (e2e)', () => {
   let app: INestApplication;
@@ -22,6 +23,7 @@ describe('Securities API (e2e)', () => {
     }).compile();
 
     app = moduleFixture.createNestApplication();
+    app.useGlobalFilters(new HttpExceptionFilter());
     app.useGlobalPipes(
       new ValidationPipe({
         transform: true,


### PR DESCRIPTION
## 概要

Issue #222: Backend E2EテストでHttpExceptionFilterが適用されていなかった問題を修正しました。

## 問題

PR #221のCIでBackend E2Eテストが失敗していました：
- `res.body.success`が`undefined`（期待値: `false`）
- E2Eテストのセットアップで`HttpExceptionFilter`がグローバルに設定されていなかった

## 修正内容

### すべてのE2Eテストファイルに`HttpExceptionFilter`を追加

- `apps/backend/test/institution.e2e-spec.ts`
- `apps/backend/test/health.e2e-spec.ts`
- `apps/backend/test/app.e2e-spec.ts`
- `apps/backend/test/securities.e2e-spec.ts`

### 変更内容

```typescript
import { HttpExceptionFilter } from '../src/common/filters/http-exception.filter';

beforeAll(async () => {
  // ... existing code ...
  
  app = moduleFixture.createNestApplication();

  // Global filters
  app.useGlobalFilters(new HttpExceptionFilter());

  // Global pipes
  app.useGlobalPipes(
    new ValidationPipe({
      whitelist: true,
      forbidNonWhitelisted: true,
      transform: true,
    }),
  );

  // ... rest of setup ...
});
```

## 効果

- ✅ E2Eテストでエラーレスポンスの形式が`main.ts`と一致
- ✅ `res.body.success`が正しく`false`になる
- ✅ PR #221のCIが成功する

## 関連

- Closes #222
- Related to #221, #214

## チェックリスト

- [x] lintエラーなし
- [x] 型安全性を確保
- [x] 全E2Eテストファイルに適用