### PR TITLE
fix: mapfileの互換性問題を修正 (#232)

### DIFF
--- a/scripts/github/projects/update-issue-status.sh
+++ b/scripts/github/projects/update-issue-status.sh
@@ -46,10 +46,9 @@ if [ -z "$ITEM_INFO" ]; then
   exit 1
 fi
 
-mapfile -t values < <(echo "$ITEM_INFO" | jq -r '.id, .status, .title')
-ITEM_ID="${values[0]}"
-CURRENT_STATUS="${values[1]}"
-TITLE="${values[2]}"
+ITEM_ID=$(echo "$ITEM_INFO" | jq -r '.id')
+CURRENT_STATUS=$(echo "$ITEM_INFO" | jq -r '.status')
+TITLE=$(echo "$ITEM_INFO" | jq -r '.title')
 
 echo "   アイテムID: $ITEM_ID"
 echo "   タイトル: $TITLE"
@@ -72,9 +71,8 @@ if [ -z "$FIELD_INFO" ]; then
   exit 1
 fi
 
-mapfile -t ids < <(echo "$FIELD_INFO" | jq -r --arg status "$STATUS" '.id, (.options[] | select(.name == $status) | .id)')
-FIELD_ID="${ids[0]}"
-STATUS_OPTION_ID="${ids[1]}"
+FIELD_ID=$(echo "$FIELD_INFO" | jq -r '.id')
+STATUS_OPTION_ID=$(echo "$FIELD_INFO" | jq -r --arg status "$STATUS" '.options[] | select(.name == $status) | .id')
 
 if [ -z "$STATUS_OPTION_ID" ]; then
   echo "❌ エラー: ステータス '${STATUS}' が見つかりませんでした"


### PR DESCRIPTION
## 📋 問題

PR #234のマージ後、`update-issue-status.sh`が動作しない問題が発生しました。

```
mapfile: command not found
```

### 原因

- `mapfile`はBash 4.0以降でのみ利用可能
- macOSのデフォルトBash（3.2）では動作しない
- zshでは `mapfile` コマンドが存在しない

Geminiレビューで`mapfile`を使った最適化が提案されましたが、互換性の問題がありました。

## 🔧 修正内容

`mapfile`を使わず、個別のjq呼び出しに戻しました。

### 変更前（動作しない）

```bash
mapfile -t values < <(echo "$ITEM_INFO" | jq -r '.id, .status, .title')
ITEM_ID="${values[0]}"
CURRENT_STATUS="${values[1]}"
TITLE="${values[2]}"
```

### 変更後（すべての環境で動作）

```bash
ITEM_ID=$(echo "$ITEM_INFO" | jq -r '.id')
CURRENT_STATUS=$(echo "$ITEM_INFO" | jq -r '.status')
TITLE=$(echo "$ITEM_INFO" | jq -r '.title')
```

## 📊 トレードオフ

### パフォーマンス
- jq呼び出し: 5回に戻る（最適化前と同じ）
- わずかなパフォーマンス低下（ただし、実用上は問題なし）

### 互換性
- ✅ すべてのシェル環境で動作（bash, zsh, sh）
- ✅ macOS、Linux、CI環境で動作
- ✅ 特定のBashバージョンに依存しない

## ✅ 動作確認

```bash
./scripts/github/projects/update-issue-status.sh 232 '🚧 In Progress'
# ✅ 正常に動作
```

## 🔗 関連

- 元Issue: #232
- 元PR: #234