### PR TITLE
[docs] POST /api/institutions エンドポイントの仕様を明確化

### DIFF
--- a/docs/detailed-design/FR-001-005_institution-integration/input-output-design.md
+++ b/docs/detailed-design/FR-001-005_institution-integration/input-output-design.md
@@ -102,9 +102,39 @@
 
 **※2**: `credentials`の構造は金融機関種別によって異なります：
 
-- **銀行 (`type: "bank"`)**: `bankCode`, `branchCode`, `accountNumber`, `apiKey`
-- **クレジットカード (`type: "credit-card"`)**: カード会社のログイン情報など
-- **証券口座 (`type: "securities"`)**: 証券会社のログイン情報など
+- **銀行 (`type: "bank"`)**:
+
+  ```json
+  {
+    "bankCode": "0005",
+    "branchCode": "001",
+    "accountNumber": "1234567",
+    "apiKey": "your-api-key-here"
+  }
+  ```
+
+- **クレジットカード (`type: "credit-card"`)**:
+
+  ```json
+  {
+    "cardNumber": "1234567812345678",
+    "cardHolderName": "TARO YAMADA",
+    "expiryDate": "2028-12-31",
+    "loginId": "user@example.com",
+    "password": "your-password"
+  }
+  ```
+
+- **証券口座 (`type: "securities"`)**:
+  ```json
+  {
+    "accountNumber": "12345678",
+    "accountType": "specific",
+    "loginId": "user@example.com",
+    "password": "your-password",
+    "tradePassword": "1234"
+  }
+  ```
 
 実装上は汎用的な`Record<string, unknown>`型で受け取りますが、各種別専用エンドポイントの使用を推奨します。
 


### PR DESCRIPTION
## 概要

Issue #213 で指摘されたAPI仕様の曖昧さを解消しました。

Closes #213

---

## 変更内容

POST /api/institutions エンドポイントの仕様を明確化しました。

### 主な変更点

1. **エンドポイントの説明を明確化**
   - 「金融機関（銀行）を登録」→「汎用金融機関登録エンドポイント」に変更
   - 全ての金融機関種別（銀行・クレジットカード・証券口座）を受け入れることを明記

2. **推奨される使用方法を追加**
   - 各金融機関種別専用エンドポイントの使用を推奨する注意書きを追加
   - 理由（最適化されたバリデーション、REST API設計原則、責務の分離）を明記

3. **リクエストスキーマを実装に合わせて修正**
   - credentials を `Record<string, unknown>` 型に変更
   - 金融機関種別ごとの credentials 構造の違いを説明

4. **レスポンス例を実装に合わせて修正**
   - 登録直後の状態（isConnected: false, accounts: []）に修正

5. **バリデーションルールを更新**
   - 実装と一致するよう修正
   - 各種別専用エンドポイントの使用推奨を追記

---

## 採用した方針

Issue #213で提案された「オプション2: 汎用エンドポイントとして明確化」を採用しました。

**理由:**
- 実装の変更が不要
- 既存の実装は汎用的で、各種別に対応済み
- ドキュメントの明確化のみで対応可能
- 各種別専用エンドポイントの使用を推奨することで、責務の分離も維持

---

## 影響範囲

- ✅ ドキュメントのみの変更
- ✅ 実装の変更なし
- ✅ API の挙動に変更なし

---

## チェックリスト

- [x] Lintチェック完了
- [x] ドキュメント変更のみ（テスト不要）
- [x] Issue報告完了
- [x] コミットメッセージが適切

---

## 関連Issue

- #213 - POST /api/institutions エンドポイントの対象範囲を明確化
- #198 - 金融機関連携機能詳細設計書作成（親Issue）