### PR TITLE
docs: FR-010費目手動修正機能の詳細設計書作成 (#277)

### DIFF
--- a/docs/detailed-design/FR-010_manual-category-edit/README.md
+++ b/docs/detailed-design/FR-010_manual-category-edit/README.md
@@ -205,16 +205,16 @@ enum CategoryType {
 
 ```sql
 CREATE TABLE transaction_category_change_history (
-  id VARCHAR(255) PRIMARY KEY,
-  transactionId VARCHAR(255) NOT NULL,
-  oldCategoryId VARCHAR(255) NOT NULL,
+  id VARCHAR(36) PRIMARY KEY,
+  transactionId VARCHAR(36) NOT NULL,
+  oldCategoryId VARCHAR(36) NOT NULL,
   oldCategoryName VARCHAR(100) NOT NULL,
   oldCategoryType ENUM('INCOME', 'EXPENSE', 'TRANSFER', 'REPAYMENT', 'INVESTMENT') NOT NULL,
-  newCategoryId VARCHAR(255) NOT NULL,
+  newCategoryId VARCHAR(36) NOT NULL,
   newCategoryName VARCHAR(100) NOT NULL,
   newCategoryType ENUM('INCOME', 'EXPENSE', 'TRANSFER', 'REPAYMENT', 'INVESTMENT') NOT NULL,
   changedAt DATETIME NOT NULL,
-  changedBy VARCHAR(255) NULL,
+  changedBy VARCHAR(36) NULL,
   INDEX idx_transaction (transactionId),
   INDEX idx_transaction_changed (transactionId, changedAt)
 );

--- a/docs/detailed-design/FR-010_manual-category-edit/class-diagrams.md
+++ b/docs/detailed-design/FR-010_manual-category-edit/class-diagrams.md
@@ -97,8 +97,10 @@ classDiagram
 - **責務**: 取引データの管理、カテゴリ更新ロジック
 - **主要メソッド**:
   - `updateCategory(newCategory)`: カテゴリを更新して新しいインスタンスを返す
-  - `toJSON()`: JSON形式への変換
+  - `toJSON()`: JSON形式への変換（戻り値は`TransactionJSONResponse`型）
 - **不変性**: Entityは基本的に不変で、更新時は新しいインスタンスを生成
+
+**注記**: `TransactionJSONResponse`は、APIレスポンス用のプレーンオブジェクト型です。`date`、`createdAt`、`updatedAt`がISO8601文字列に変換されます。
 
 #### TransactionCategoryChangeHistoryEntity
 
@@ -285,7 +287,6 @@ classDiagram
     class UpdateTransactionCategoryRequestDto {
         <<class>>
         +CategoryRequestDto category
-        +validate() boolean
     }
 
     class CategoryRequestDto {
@@ -332,12 +333,9 @@ classDiagram
 
 #### UpdateTransactionCategoryRequestDto
 
-- **責務**: リクエストデータの受け取りとバリデーション
-- **バリデーション**:
-  - `category`は必須
-  - `category.id`は文字列で必須
-  - `category.name`は文字列で必須
-  - `category.type`はCategoryType enumで必須
+- **責務**: リクエストデータの受け取り
+- **バリデーション**: NestJSの`ValidationPipe`によって自動的にバリデーションが実行されます
+- **デコレータ**: `class-validator`のデコレータ（`@IsObject`、`@ValidateNested`等）で宣言的にバリデーションルールを定義
 
 #### TransactionResponseDto
 
@@ -429,7 +427,7 @@ graph TD
     A[Presentation Layer] -->|依存| B[Application Layer]
     B -->|依存| C[Domain Layer]
     A -->|依存| C
-    D[Infrastructure Layer] -->|実装| C
+    D[Infrastructure Layer] ..|>|実装| C
 
     style A fill:#e1f5ff
     style B fill:#fff4e1

--- a/docs/detailed-design/FR-010_manual-category-edit/input-output-design.md
+++ b/docs/detailed-design/FR-010_manual-category-edit/input-output-design.md
@@ -234,16 +234,16 @@ export enum TransactionStatus {
 
 ```sql
 CREATE TABLE transaction_category_change_history (
-  id VARCHAR(255) PRIMARY KEY,
-  transactionId VARCHAR(255) NOT NULL,
-  oldCategoryId VARCHAR(255) NOT NULL,
+  id VARCHAR(36) PRIMARY KEY,
+  transactionId VARCHAR(36) NOT NULL,
+  oldCategoryId VARCHAR(36) NOT NULL,
   oldCategoryName VARCHAR(100) NOT NULL,
   oldCategoryType ENUM('INCOME', 'EXPENSE', 'TRANSFER', 'REPAYMENT', 'INVESTMENT') NOT NULL,
-  newCategoryId VARCHAR(255) NOT NULL,
+  newCategoryId VARCHAR(36) NOT NULL,
   newCategoryName VARCHAR(100) NOT NULL,
   newCategoryType ENUM('INCOME', 'EXPENSE', 'TRANSFER', 'REPAYMENT', 'INVESTMENT') NOT NULL,
   changedAt DATETIME NOT NULL,
-  changedBy VARCHAR(255) NULL,
+  changedBy VARCHAR(36) NULL,
   INDEX idx_transaction (transactionId),
   INDEX idx_transaction_changed (transactionId, changedAt)
 );
@@ -258,7 +258,7 @@ CREATE TABLE transaction_category_change_history (
 
 ```sql
 -- カテゴリ関連フィールド
-categoryId VARCHAR(255) NOT NULL,
+categoryId VARCHAR(36) NOT NULL,
 categoryName VARCHAR(100) NOT NULL,
 categoryType ENUM('INCOME', 'EXPENSE', 'TRANSFER', 'REPAYMENT', 'INVESTMENT') NOT NULL,
 updatedAt DATETIME NOT NULL

--- a/docs/detailed-design/FR-010_manual-category-edit/sequence-diagrams.md
+++ b/docs/detailed-design/FR-010_manual-category-edit/sequence-diagrams.md
@@ -74,7 +74,7 @@ sequenceDiagram
     HisRepo->>DB: INSERT INTO<br/>transaction_category_change_history
 
     UC->>TxRepo: entityManager.save(transaction)
-    TxRepo->>DB: UPDATE transactions<br/>SET category*
+    TxRepo->>DB: UPDATE transactions<br/>SET categoryId, categoryName, categoryType, updatedAt
 
     UC->>DB: COMMIT
     Note over UC,DB: DBトランザクション完了
@@ -202,8 +202,7 @@ sequenceDiagram
     UC->>DB: UPDATE transaction
     DB--xUC: DatabaseError<br/>(例: デッドロック)
 
-    UC->>DB: ROLLBACK
-    Note over UC,DB: トランザクション自動ロールバック
+    Note over UC,DB: TypeORMが自動的にロールバック
 
     UC->>UC: エラーログ出力
     UC-->>API: throw InternalServerErrorException


### PR DESCRIPTION
## 概要

Issue #31（FR-010: 費目の手動修正機能）の実装が完了したため、事後ドキュメント化として詳細設計書を作成しました。

## 作成したドキュメント

### 1. README.md
- プロジェクト概要
- アーキテクチャ構成（Onion Architecture）
- 技術スタック
- データベース設計
- 主要コンポーネント
- テスト戦略
- 実装時の設計判断

### 2. class-diagrams.md
- Domain層、Application層、Infrastructure層、Presentation層のクラス図
- Frontend コンポーネント図
- Mermaid図による可視化
- クラス間の関係性と依存関係

### 3. sequence-diagrams.md
- カテゴリ更新の正常系・異常系フロー
- データベーストランザクションの詳細
- Frontend UIフロー
- エラーハンドリング

### 4. input-output-design.md
- API仕様（PATCH /api/transactions/:id/category）
- リクエスト/レスポンススキーマ
- データモデル定義
- エラーレスポンス仕様
- バリデーションルール
- API使用例（cURL、TypeScript）

## 実装内容

### Backend
- `UpdateTransactionCategoryUseCase`: カテゴリ更新ユースケース
- `TransactionCategoryChangeHistoryEntity`: 変更履歴エンティティ
- TypeORMによるデータベーストランザクション管理

### Frontend
- `TransactionList`コンポーネント: インライン編集機能
- カテゴリ選択UIとエラーハンドリング

## 技術的なポイント

### データベーストランザクション
- `DataSource.transaction`を使用して、変更履歴の記録と取引の更新をアトミックに実行
- トランザクション外で取引の存在確認を実施（パフォーマンス最適化）

### 型安全性
- リクエストDTOは`class`で定義（バリデーションデコレータ使用）
- レスポンスDTOは`interface`で定義（プロパティ初期化不要）

### インデックス設計
- `idx_transaction`: transactionIdによる検索の高速化
- `idx_transaction_changed`: transactionIdとchangedAtの複合インデックス

## テスト実績

- ユニットテスト: 5件
- Backend E2Eテスト: 3件
- Frontend E2Eテスト: 7件（一時的にスキップ中）

## 参考資料

- 機能要件書: `docs/functional-requirements/FR-008-011_data-classification.md` (L535-714)
- Issue #31: FR-010: 費目の手動修正機能
- PR #275: feat: FR-010費目手動修正機能の完全実装

## チェックリスト

- [x] README.md 作成完了
- [x] class-diagrams.md 作成完了
- [x] sequence-diagrams.md 作成完了
- [x] input-output-design.md 作成完了
- [x] Mermaid図を使用した可視化
- [x] API仕様の詳細記載
- [x] TypeScript型定義の記載
- [x] データベーススキーマの記載

Closes #277