### PR TITLE
feat(frontend): FR-024 年間収支グラフ表示機能を実装

### DIFF
--- a/apps/frontend/src/components/dashboard/YearlyBalanceGraph.tsx
+++ b/apps/frontend/src/components/dashboard/YearlyBalanceGraph.tsx
@@ -1,0 +1,196 @@
+'use client';
+
+import React, { useMemo, useId } from 'react';
+import {
+  BarChart,
+  Bar,
+  LineChart,
+  Line,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+  ComposedChart,
+} from 'recharts';
+import { Card, CardHeader, CardTitle, CardContent } from '../ui/Card';
+import { formatCurrency } from '@account-book/utils';
+import type { YearlyBalanceResponse } from '@/lib/api/aggregation';
+import { CustomTooltip } from './CustomTooltip';
+
+interface YearlyBalanceGraphProps {
+  data: YearlyBalanceResponse;
+}
+
+// グラフのカラー定数
+const COLOR_INCOME = '#4CAF50';
+const COLOR_EXPENSE = '#F44336';
+const COLOR_BALANCE_POSITIVE = '#2196F3';
+const COLOR_BALANCE_NEGATIVE = '#FF9800';
+
+/**
+ * 年間収支グラフコンポーネント
+ * FR-024: 年間収支グラフ表示
+ */
+export function YearlyBalanceGraph({ data }: YearlyBalanceGraphProps): React.JSX.Element {
+  // 一意なIDを生成（linearGradientのID衝突を防ぐ）
+  const uniqueId = useId();
+  const balancePositiveGradientId = `colorBalancePositive-${uniqueId}`;
+  const balanceNegativeGradientId = `colorBalanceNegative-${uniqueId}`;
+
+  // 月別データをグラフ用に変換（1月〜12月）
+  const monthlyData = useMemo(() => {
+    return data.months.map((month) => {
+      // 月のラベル（1月、2月...）
+      const monthNum = parseInt(month.month.split('-')[1] || '0', 10);
+      const monthLabel = `${monthNum}月`;
+
+      return {
+        month: monthLabel,
+        monthNum,
+        income: month.income.total,
+        expense: month.expense.total,
+        balance: month.balance,
+        savingsRate: month.savingsRate,
+      };
+    });
+  }, [data.months]);
+
+  // 月別折れ線グラフ用データ（収入・支出・収支の3本の線）
+  const lineChartData = useMemo(() => {
+    return monthlyData;
+  }, [monthlyData]);
+
+  // 月別積み上げ棒グラフ用データ（収入バーと支出バー）
+  const barChartData = useMemo(() => {
+    return monthlyData;
+  }, [monthlyData]);
+
+  // 収支差額エリアグラフ用データ（0を基準にプラス/マイナス）
+  // プラスとマイナスを分けて描画するため、2つのデータセットを作成
+  const areaChartData = useMemo(() => {
+    return monthlyData.map((item) => ({
+      month: item.month,
+      monthNum: item.monthNum,
+      balance: item.balance,
+      positiveBalance: item.balance >= 0 ? item.balance : 0,
+      negativeBalance: item.balance < 0 ? item.balance : 0,
+    }));
+  }, [monthlyData]);
+
+  return (
+    <div className="space-y-6">
+      {/* 月別折れ線グラフ */}
+      <Card>
+        <CardHeader>
+          <CardTitle>月別推移（折れ線グラフ）</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ResponsiveContainer width="100%" height={300}>
+            <LineChart data={lineChartData} margin={{ top: 5, right: 30, left: 20, bottom: 5 }}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="month" />
+              <YAxis tickFormatter={(value: number) => formatCurrency(value)} />
+              <Tooltip content={<CustomTooltip />} />
+              <Legend />
+              <Line
+                type="monotone"
+                dataKey="income"
+                stroke={COLOR_INCOME}
+                strokeWidth={2}
+                name="収入"
+                dot={{ r: 4 }}
+              />
+              <Line
+                type="monotone"
+                dataKey="expense"
+                stroke={COLOR_EXPENSE}
+                strokeWidth={2}
+                name="支出"
+                dot={{ r: 4 }}
+              />
+              <Line
+                type="monotone"
+                dataKey="balance"
+                stroke={
+                  data.annual.totalBalance >= 0 ? COLOR_BALANCE_POSITIVE : COLOR_BALANCE_NEGATIVE
+                }
+                strokeWidth={2}
+                name="収支"
+                dot={{ r: 4 }}
+              />
+            </LineChart>
+          </ResponsiveContainer>
+        </CardContent>
+      </Card>
+
+      {/* 月別積み上げ棒グラフ */}
+      <Card>
+        <CardHeader>
+          <CardTitle>月別比較（棒グラフ）</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ResponsiveContainer width="100%" height={300}>
+            <BarChart data={barChartData} margin={{ top: 5, right: 30, left: 20, bottom: 5 }}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="month" />
+              <YAxis tickFormatter={(value: number) => formatCurrency(value)} />
+              <Tooltip content={<CustomTooltip />} />
+              <Legend />
+              <Bar dataKey="income" fill={COLOR_INCOME} name="収入" />
+              <Bar dataKey="expense" fill={COLOR_EXPENSE} name="支出" />
+            </BarChart>
+          </ResponsiveContainer>
+        </CardContent>
+      </Card>
+
+      {/* 収支差額エリアグラフ */}
+      <Card>
+        <CardHeader>
+          <CardTitle>収支差額（エリアグラフ）</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ResponsiveContainer width="100%" height={300}>
+            <ComposedChart data={areaChartData} margin={{ top: 5, right: 30, left: 20, bottom: 5 }}>
+              <defs>
+                <linearGradient id={balancePositiveGradientId} x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="5%" stopColor={COLOR_BALANCE_POSITIVE} stopOpacity={0.8} />
+                  <stop offset="95%" stopColor={COLOR_BALANCE_POSITIVE} stopOpacity={0} />
+                </linearGradient>
+                <linearGradient id={balanceNegativeGradientId} x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="5%" stopColor={COLOR_BALANCE_NEGATIVE} stopOpacity={0.8} />
+                  <stop offset="95%" stopColor={COLOR_BALANCE_NEGATIVE} stopOpacity={0} />
+                </linearGradient>
+              </defs>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="month" />
+              <YAxis tickFormatter={(value: number) => formatCurrency(value)} />
+              <Tooltip content={<CustomTooltip />} />
+              <Legend />
+              {/* プラスのエリア */}
+              <Area
+                type="monotone"
+                dataKey="positiveBalance"
+                stroke={COLOR_BALANCE_POSITIVE}
+                fillOpacity={1}
+                fill={`url(#${balancePositiveGradientId})`}
+                name="収支（プラス）"
+              />
+              {/* マイナスのエリア */}
+              <Area
+                type="monotone"
+                dataKey="negativeBalance"
+                stroke={COLOR_BALANCE_NEGATIVE}
+                fillOpacity={1}
+                fill={`url(#${balanceNegativeGradientId})`}
+                name="収支（マイナス）"
+              />
+            </ComposedChart>
+          </ResponsiveContainer>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/dashboard/__tests__/YearlyBalanceGraph.test.tsx
+++ b/apps/frontend/src/components/dashboard/__tests__/YearlyBalanceGraph.test.tsx
@@ -1,0 +1,298 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { YearlyBalanceGraph } from '../YearlyBalanceGraph';
+import type { YearlyBalanceResponse } from '@/lib/api/aggregation';
+
+// Rechartsのモック
+jest.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="responsive-container">{children}</div>
+  ),
+  LineChart: ({ children, data }: { children: React.ReactNode; data?: unknown[] }) => (
+    <div data-testid="line-chart" data-chart-data={JSON.stringify(data)}>
+      {children}
+    </div>
+  ),
+  BarChart: ({ children, data }: { children: React.ReactNode; data?: unknown[] }) => (
+    <div data-testid="bar-chart" data-chart-data={JSON.stringify(data)}>
+      {children}
+    </div>
+  ),
+  ComposedChart: ({ children, data }: { children: React.ReactNode; data?: unknown[] }) => (
+    <div data-testid="composed-chart" data-chart-data={JSON.stringify(data)}>
+      {children}
+    </div>
+  ),
+  Line: () => <div data-testid="line" />,
+  Bar: () => <div data-testid="bar" />,
+  Area: () => <div data-testid="area" />,
+  XAxis: () => <div data-testid="x-axis" />,
+  YAxis: () => <div data-testid="y-axis" />,
+  CartesianGrid: () => <div data-testid="cartesian-grid" />,
+  Tooltip: () => <div data-testid="tooltip" />,
+  Legend: () => <div data-testid="legend" />,
+}));
+
+describe('YearlyBalanceGraph', () => {
+  const mockData: YearlyBalanceResponse = {
+    year: 2025,
+    months: [
+      {
+        month: '2025-01',
+        income: {
+          total: 300000,
+          count: 1,
+          byCategory: [],
+          byInstitution: [],
+          transactions: [],
+        },
+        expense: {
+          total: 200000,
+          count: 5,
+          byCategory: [],
+          byInstitution: [],
+          transactions: [],
+        },
+        balance: 100000,
+        savingsRate: 33.33,
+      },
+      {
+        month: '2025-02',
+        income: {
+          total: 300000,
+          count: 1,
+          byCategory: [],
+          byInstitution: [],
+          transactions: [],
+        },
+        expense: {
+          total: 180000,
+          count: 4,
+          byCategory: [],
+          byInstitution: [],
+          transactions: [],
+        },
+        balance: 120000,
+        savingsRate: 40.0,
+      },
+      {
+        month: '2025-03',
+        income: {
+          total: 300000,
+          count: 1,
+          byCategory: [],
+          byInstitution: [],
+          transactions: [],
+        },
+        expense: {
+          total: 250000,
+          count: 6,
+          byCategory: [],
+          byInstitution: [],
+          transactions: [],
+        },
+        balance: 50000,
+        savingsRate: 16.67,
+      },
+    ],
+    annual: {
+      totalIncome: 900000,
+      totalExpense: 630000,
+      totalBalance: 270000,
+      averageIncome: 300000,
+      averageExpense: 210000,
+      savingsRate: 30.0,
+    },
+    trend: {
+      incomeProgression: {
+        direction: 'stable',
+        changeRate: 0.0,
+        standardDeviation: 0,
+      },
+      expenseProgression: {
+        direction: 'decreasing',
+        changeRate: -1.5,
+        standardDeviation: 15000,
+      },
+      balanceProgression: {
+        direction: 'increasing',
+        changeRate: 2.0,
+        standardDeviation: 10000,
+      },
+    },
+    highlights: {
+      maxIncomeMonth: '2025-01',
+      maxExpenseMonth: '2025-03',
+      bestBalanceMonth: '2025-02',
+      worstBalanceMonth: '2025-03',
+    },
+  };
+
+  it('月別推移（折れ線グラフ）を表示する', () => {
+    render(<YearlyBalanceGraph data={mockData} />);
+    expect(screen.getByText('月別推移（折れ線グラフ）')).toBeInTheDocument();
+    expect(screen.getByTestId('line-chart')).toBeInTheDocument();
+  });
+
+  it('月別比較（棒グラフ）を表示する', () => {
+    render(<YearlyBalanceGraph data={mockData} />);
+    expect(screen.getByText('月別比較（棒グラフ）')).toBeInTheDocument();
+    expect(screen.getByTestId('bar-chart')).toBeInTheDocument();
+  });
+
+  it('収支差額（エリアグラフ）を表示する', () => {
+    render(<YearlyBalanceGraph data={mockData} />);
+    expect(screen.getByText('収支差額（エリアグラフ）')).toBeInTheDocument();
+    expect(screen.getByTestId('composed-chart')).toBeInTheDocument();
+  });
+
+  it('月別データが正しく変換される', () => {
+    render(<YearlyBalanceGraph data={mockData} />);
+    const lineChart = screen.getByTestId('line-chart');
+    const chartData = JSON.parse(lineChart.getAttribute('data-chart-data') || '[]');
+
+    expect(chartData.length).toBe(3);
+    expect(chartData[0]).toHaveProperty('month', '1月');
+    expect(chartData[0]).toHaveProperty('income', 300000);
+    expect(chartData[0]).toHaveProperty('expense', 200000);
+    expect(chartData[0]).toHaveProperty('balance', 100000);
+  });
+
+  it('データが空の場合でもエラーなく表示する', () => {
+    const emptyData: YearlyBalanceResponse = {
+      year: 2025,
+      months: [],
+      annual: {
+        totalIncome: 0,
+        totalExpense: 0,
+        totalBalance: 0,
+        averageIncome: 0,
+        averageExpense: 0,
+        savingsRate: 0,
+      },
+      trend: {
+        incomeProgression: {
+          direction: 'stable',
+          changeRate: 0,
+          standardDeviation: 0,
+        },
+        expenseProgression: {
+          direction: 'stable',
+          changeRate: 0,
+          standardDeviation: 0,
+        },
+        balanceProgression: {
+          direction: 'stable',
+          changeRate: 0,
+          standardDeviation: 0,
+        },
+      },
+      highlights: {
+        maxIncomeMonth: null,
+        maxExpenseMonth: null,
+        bestBalanceMonth: null,
+        worstBalanceMonth: null,
+      },
+    };
+
+    render(<YearlyBalanceGraph data={emptyData} />);
+    expect(screen.getByText('月別推移（折れ線グラフ）')).toBeInTheDocument();
+    expect(screen.getByText('月別比較（棒グラフ）')).toBeInTheDocument();
+    expect(screen.getByText('収支差額（エリアグラフ）')).toBeInTheDocument();
+  });
+
+  it('12ヶ月分のデータを正しく処理する', () => {
+    const fullYearData: YearlyBalanceResponse = {
+      ...mockData,
+      months: Array.from({ length: 12 }, (_, i) => ({
+        month: `2025-${String(i + 1).padStart(2, '0')}`,
+        income: {
+          total: 300000,
+          count: 1,
+          byCategory: [],
+          byInstitution: [],
+          transactions: [],
+        },
+        expense: {
+          total: 200000,
+          count: 5,
+          byCategory: [],
+          byInstitution: [],
+          transactions: [],
+        },
+        balance: 100000,
+        savingsRate: 33.33,
+      })),
+    };
+
+    render(<YearlyBalanceGraph data={fullYearData} />);
+    const lineChart = screen.getByTestId('line-chart');
+    const chartData = JSON.parse(lineChart.getAttribute('data-chart-data') || '[]');
+
+    expect(chartData.length).toBe(12);
+    expect(chartData[0]).toHaveProperty('month', '1月');
+    expect(chartData[11]).toHaveProperty('month', '12月');
+  });
+
+  it('収支差額エリアグラフでプラスとマイナスが正しく分離される', () => {
+    const mixedBalanceData: YearlyBalanceResponse = {
+      ...mockData,
+      months: [
+        {
+          month: '2025-01',
+          income: {
+            total: 300000,
+            count: 1,
+            byCategory: [],
+            byInstitution: [],
+            transactions: [],
+          },
+          expense: {
+            total: 200000,
+            count: 5,
+            byCategory: [],
+            byInstitution: [],
+            transactions: [],
+          },
+          balance: 100000, // プラス
+          savingsRate: 33.33,
+        },
+        {
+          month: '2025-02',
+          income: {
+            total: 200000,
+            count: 1,
+            byCategory: [],
+            byInstitution: [],
+            transactions: [],
+          },
+          expense: {
+            total: 250000,
+            count: 6,
+            byCategory: [],
+            byInstitution: [],
+            transactions: [],
+          },
+          balance: -50000, // マイナス
+          savingsRate: -25.0,
+        },
+      ],
+    };
+
+    render(<YearlyBalanceGraph data={mixedBalanceData} />);
+    const composedChart = screen.getByTestId('composed-chart');
+    const chartData = JSON.parse(composedChart.getAttribute('data-chart-data') || '[]');
+
+    expect(chartData[0]).toHaveProperty('positiveBalance', 100000);
+    expect(chartData[0]).toHaveProperty('negativeBalance', 0);
+    expect(chartData[1]).toHaveProperty('positiveBalance', 0);
+    expect(chartData[1]).toHaveProperty('negativeBalance', -50000);
+  });
+
+  it('ツールチップコンポーネントが存在する', () => {
+    render(<YearlyBalanceGraph data={mockData} />);
+    const tooltips = screen.getAllByTestId('tooltip');
+    // 3つのグラフすべてにツールチップがあることを確認
+    expect(tooltips.length).toBe(3);
+  });
+});

--- a/apps/frontend/src/lib/api/aggregation.ts
+++ b/apps/frontend/src/lib/api/aggregation.ts
@@ -2,6 +2,7 @@
  * 月別集計APIクライアント
  * FR-012: クレジットカード月別集計
  * FR-016: 月別収支集計
+ * FR-020: 年間収支推移表示
  */
 
 import { CategoryAmount } from '@account-book/types';
@@ -116,6 +117,60 @@ export interface MonthlyBalanceResponse {
 }
 
 /**
+ * 年間収支集計レスポンス（FR-020）
+ */
+
+// トレンド分析
+export interface TrendAnalysis {
+  direction: 'increasing' | 'decreasing' | 'stable';
+  changeRate: number;
+  standardDeviation: number;
+}
+
+// トレンドデータ
+export interface TrendData {
+  incomeProgression: TrendAnalysis;
+  expenseProgression: TrendAnalysis;
+  balanceProgression: TrendAnalysis;
+}
+
+// 年間サマリー
+export interface AnnualSummary {
+  totalIncome: number;
+  totalExpense: number;
+  totalBalance: number;
+  averageIncome: number;
+  averageExpense: number;
+  savingsRate: number;
+}
+
+// ハイライト情報
+export interface Highlights {
+  maxIncomeMonth: string | null; // YYYY-MM
+  maxExpenseMonth: string | null; // YYYY-MM
+  bestBalanceMonth: string | null; // YYYY-MM
+  worstBalanceMonth: string | null; // YYYY-MM
+}
+
+// 月別サマリー（年間集計用の簡略版、comparisonフィールドなし）
+export interface MonthlyBalanceSummary {
+  month: string; // YYYY-MM
+  income: MonthlyBalanceDetails;
+  expense: MonthlyBalanceDetails;
+  balance: number;
+  savingsRate: number;
+}
+
+// 年間収支集計レスポンス
+export interface YearlyBalanceResponse {
+  year: number;
+  months: MonthlyBalanceSummary[];
+  annual: AnnualSummary;
+  trend: TrendData;
+  highlights: Highlights;
+}
+
+/**
  * 月別集計APIクライアント
  */
 export const aggregationApi = {
@@ -162,6 +217,15 @@ export const aggregationApi = {
   getMonthlyBalance: async (year: number, month: number): Promise<MonthlyBalanceResponse> => {
     return await apiClient.get<MonthlyBalanceResponse>(
       `/api/aggregation/monthly-balance?year=${year}&month=${month}`
+    );
+  },
+
+  /**
+   * 年間収支集計情報を取得（FR-020）
+   */
+  getYearlyBalance: async (year: number): Promise<YearlyBalanceResponse> => {
+    return await apiClient.get<YearlyBalanceResponse>(
+      `/api/aggregation/yearly-balance?year=${year}`
     );
   },
 };


### PR DESCRIPTION
## 📋 概要

FR-024: 年間収支グラフ表示機能の実装

## 🎯 関連Issue

Closes #53

## 📊 変更内容

### 型定義・APIクライアント
- `YearlyBalanceResponse`型を追加
- `MonthlyBalanceSummary`、`AnnualSummary`、`TrendData`、`Highlights`などの型を追加
- `aggregationApi.getYearlyBalance(year: number)`メソッドを追加

### グラフコンポーネント
- `YearlyBalanceGraph`コンポーネントを実装
- 3種類のグラフを実装：
  - **月別折れ線グラフ**: 収入・支出・収支の3本の線
  - **月別積み上げ棒グラフ**: 収入バーと支出バー
  - **収支差額エリアグラフ**: 0を基準にプラス/マイナスで色分け

### テスト
- `YearlyBalanceGraph`のユニットテストを実装（8つのテストケース）

## ✅ 実装状況

- [x] 基本実装完了
- [x] ユニットテスト追加
- [ ] E2Eテスト追加（別Issue #375で対応）
- [ ] ページ統合（別Issue #374で対応）
- [ ] ドキュメント更新

## 🧪 テスト結果

### ローカル実行

- ✅ **Build**: 成功
- ✅ **Lint**: エラーなし
- ✅ **Unit Test**: 全テストパス (197 tests)

### 実行コマンド

```bash
./scripts/test/lint.sh
pnpm build
./scripts/test/test.sh all
```

## 📂 変更ファイル

### 新規作成（2 ファイル）

- `apps/frontend/src/components/dashboard/YearlyBalanceGraph.tsx`
- `apps/frontend/src/components/dashboard/__tests__/YearlyBalanceGraph.test.tsx`

### 更新（1 ファイル）

- `apps/frontend/src/lib/api/aggregation.ts` - 型定義とAPIクライアントメソッドを追加

## 🔍 レビュー観点

### 重点確認項目

- [ ] 型定義が正しく実装されているか
- [ ] グラフコンポーネントが要件通りに実装されているか
- [ ] テストが適切に実装されているか

### 注意点

- ページ統合とE2Eテストは別Issue（#374, #375）で対応予定
- 既存の`MonthlyBalanceGraph`コンポーネントを参考に実装

## 📝 備考

- バックエンドAPI（`/api/aggregation/yearly-balance`）は既に実装済み（FR-020）
- コンポーネントは実装済みだが、実際のページへの統合は別Issueで対応