### PR TITLE
test: 金融機関更新機能のコントローラーテストを追加 (Issue #75)

### DIFF
--- a/apps/backend/src/modules/institution/presentation/controllers/institution.controller.spec.ts
+++ b/apps/backend/src/modules/institution/presentation/controllers/institution.controller.spec.ts
@@ -14,6 +14,7 @@ describe('InstitutionController', () => {
   let controller: InstitutionController;
   let createUseCase: jest.Mocked<CreateInstitutionUseCase>;
   let getUseCase: jest.Mocked<GetInstitutionsUseCase>;
+  let updateUseCase: jest.Mocked<UpdateInstitutionUseCase>;
   let deleteUseCase: jest.Mocked<DeleteInstitutionUseCase>;
 
   const mockCredentials = new EncryptedCredentials(
@@ -72,6 +73,7 @@ describe('InstitutionController', () => {
     controller = module.get<InstitutionController>(InstitutionController);
     createUseCase = module.get(CreateInstitutionUseCase);
     getUseCase = module.get(GetInstitutionsUseCase);
+    updateUseCase = module.get(UpdateInstitutionUseCase);
     deleteUseCase = module.get(DeleteInstitutionUseCase);
   });
 
@@ -100,6 +102,68 @@ describe('InstitutionController', () => {
 
       expect(result.success).toBe(true);
       expect(result.data).toHaveLength(1);
+    });
+  });
+
+  describe('update', () => {
+    it('should update an institution', async () => {
+      const updatedInstitution = new InstitutionEntity(
+        mockInstitution.id,
+        'Updated Bank',
+        mockInstitution.type,
+        mockInstitution.credentials,
+        mockInstitution.isConnected,
+        mockInstitution.lastSyncedAt,
+        mockInstitution.accounts,
+        mockInstitution.createdAt,
+        new Date(),
+      );
+
+      updateUseCase.execute.mockResolvedValue(updatedInstitution);
+
+      const result = await controller.update(mockInstitution.id, {
+        name: 'Updated Bank',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual(updatedInstitution.toJSON());
+      expect(updateUseCase.execute).toHaveBeenCalledWith(mockInstitution.id, {
+        name: 'Updated Bank',
+      });
+    });
+
+    it('should update institution credentials', async () => {
+      const updatedInstitution = new InstitutionEntity(
+        mockInstitution.id,
+        mockInstitution.name,
+        mockInstitution.type,
+        mockInstitution.credentials,
+        mockInstitution.isConnected,
+        mockInstitution.lastSyncedAt,
+        mockInstitution.accounts,
+        mockInstitution.createdAt,
+        new Date(),
+      );
+
+      updateUseCase.execute.mockResolvedValue(updatedInstitution);
+
+      const result = await controller.update(mockInstitution.id, {
+        credentials: {
+          bankCode: '9999',
+          branchCode: '999',
+          accountNumber: '9999999',
+        },
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual(updatedInstitution.toJSON());
+      expect(updateUseCase.execute).toHaveBeenCalledWith(mockInstitution.id, {
+        credentials: {
+          bankCode: '9999',
+          branchCode: '999',
+          accountNumber: '9999999',
+        },
+      });
     });
   });
 


### PR DESCRIPTION
## 概要

Issue #75「FR-028: 金融機関の登録・編集・削除機能」の完了確認として、金融機関更新機能のコントローラーテストを追加しました。

## 変更内容

- のメソッドのテストを追加
  - 金融機関名の更新テスト
  - 認証情報の更新テスト

## 関連Issue

- Issue #75: [FEATURE] FR-028: 金融機関の登録・編集・削除機能
- Issue #350: [TASK] 金融機関編集機能の実装

## テスト結果

- ✅ すべてのテストがパス（275 passed）
- ✅ lintチェック完了
- ✅ ビルド成功

## 完了確認

すべての個別タスクIssueが完了していることを確認しました：
- ✅ Issue #114: E-8: 金融機関設定画面の実装
- ✅ Issue #354: 金融機関登録機能の実装
- ✅ Issue #350: 金融機関編集機能の実装
- ✅ Issue #351: 金融機関削除機能の実装

このPRマージ後、Issue #75をCloseします。