### PR TITLE
fix: focus-trap-reactモジュールエラーとDockerビルドエラーの修正

### DIFF
--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -11,7 +11,9 @@ COPY apps/frontend/package.json ./apps/frontend/
 COPY libs/types/package.json ./libs/types/
 COPY libs/utils/package.json ./libs/utils/
 
-RUN pnpm install --frozen-lockfile
+# postinstallスクリプトをスキップ（Alpine LinuxではPlaywrightの--with-depsが動作しないため）
+# 本番環境ではPlaywrightのブラウザインストールは不要
+RUN pnpm install --frozen-lockfile --ignore-scripts
 
 # ソースコードのコピーとビルド
 COPY . .

--- a/apps/frontend/Dockerfile.dev
+++ b/apps/frontend/Dockerfile.dev
@@ -13,7 +13,9 @@ COPY apps/frontend/package.json ./apps/frontend/
 COPY libs/types/package.json ./libs/types/
 COPY libs/utils/package.json ./libs/utils/
 
-RUN pnpm install --frozen-lockfile
+# postinstallスクリプトをスキップ（Alpine LinuxではPlaywrightの--with-depsが動作しないため）
+# 開発環境ではPlaywrightのブラウザインストールは不要（E2Eテストは別コンテナで実行）
+RUN pnpm install --frozen-lockfile --ignore-scripts
 
 # ソースコードのコピー
 COPY . .


### PR DESCRIPTION
## 📋 概要

Issue #406「[bug] focus-trap-reactモジュールが見つからないエラー」の修正と、関連するDockerビルドエラーの修正を行いました。

## 🐛 修正内容

### 1. focus-trap-reactモジュールの確認

- `pnpm install`を実行して依存関係を確認
- `focus-trap-react@11.0.4`が正しくインストールされていることを確認
- ビルドが成功することを確認

### 2. Dockerビルドエラーの修正

Alpine LinuxベースのDockerイメージで`pnpm install`を実行すると、Playwrightのpostinstallスクリプトが`apt-get`を使用しようとして失敗していました。

**修正内容**:
- `apps/frontend/Dockerfile.dev`: `--ignore-scripts`オプションを追加
- `apps/frontend/Dockerfile`: `--ignore-scripts`オプションを追加

**理由**:
- 開発環境ではPlaywrightのブラウザインストールは不要（E2Eテストは別コンテナで実行）
- 本番環境でもPlaywrightは不要
- Alpine Linuxでは`--with-deps`オプションは動作しない（`apt-get`が存在しない）

## ✅ 確認事項

- [x] `pnpm install`を実行して依存関係をインストール
- [x] ビルドエラーが解消されることを確認
- [x] Dockerビルドエラーが解消されることを確認
- [x] lintチェックが成功することを確認
- [x] ビルドが成功することを確認

## 🔗 関連Issue

Closes #406

## 📝 備考

実際には、依存関係は既に正しくインストールされており、`pnpm install`を実行したことで依存関係が確認されました。ビルドも成功しており、TypeScriptの型チェックでもエラーは見つかりませんでした。

Dockerビルドエラーについては、Alpine LinuxベースのイメージでPlaywrightのpostinstallスクリプトが動作しないため、`--ignore-scripts`オプションを追加して修正しました。