### PR TITLE
[FEATURE] FR-002: クレジットカード追加画面の実装

### DIFF
--- a/apps/backend/src/modules/credit-card/application/use-cases/get-supported-card-companies.use-case.spec.ts
+++ b/apps/backend/src/modules/credit-card/application/use-cases/get-supported-card-companies.use-case.spec.ts
@@ -1,0 +1,218 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { GetSupportedCardCompaniesUseCase } from './get-supported-card-companies.use-case';
+import { CardCompanyCategory } from '@account-book/types';
+
+describe('GetSupportedCardCompaniesUseCase', () => {
+  let useCase: GetSupportedCardCompaniesUseCase;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [GetSupportedCardCompaniesUseCase],
+    }).compile();
+
+    useCase = module.get<GetSupportedCardCompaniesUseCase>(
+      GetSupportedCardCompaniesUseCase,
+    );
+  });
+
+  it('should be defined', () => {
+    expect(useCase).toBeDefined();
+  });
+
+  describe('execute', () => {
+    it('should return all supported card companies when no query is provided', () => {
+      const companies = useCase.execute();
+
+      expect(companies).toBeInstanceOf(Array);
+      expect(companies.length).toBeGreaterThan(0);
+      expect(companies.every((company) => company.isSupported)).toBe(true);
+    });
+
+    it('should return companies with correct structure', () => {
+      const companies = useCase.execute();
+      const company = companies[0];
+
+      expect(company).toMatchObject({
+        id: expect.any(String),
+        code: expect.any(String),
+        name: expect.any(String),
+        category: expect.any(String),
+        isSupported: expect.any(Boolean),
+      });
+    });
+
+    it('should filter companies by category (MAJOR)', () => {
+      const companies = useCase.execute({
+        category: CardCompanyCategory.MAJOR,
+      });
+
+      expect(companies.length).toBeGreaterThan(0);
+      expect(
+        companies.every(
+          (company) => company.category === CardCompanyCategory.MAJOR,
+        ),
+      ).toBe(true);
+    });
+
+    it('should filter companies by category (BANK)', () => {
+      const companies = useCase.execute({
+        category: CardCompanyCategory.BANK,
+      });
+
+      expect(companies.length).toBeGreaterThan(0);
+      expect(
+        companies.every(
+          (company) => company.category === CardCompanyCategory.BANK,
+        ),
+      ).toBe(true);
+    });
+
+    it('should filter companies by category (RETAIL)', () => {
+      const companies = useCase.execute({
+        category: CardCompanyCategory.RETAIL,
+      });
+
+      expect(companies.length).toBeGreaterThan(0);
+      expect(
+        companies.every(
+          (company) => company.category === CardCompanyCategory.RETAIL,
+        ),
+      ).toBe(true);
+    });
+
+    it('should filter companies by category (ONLINE)', () => {
+      const companies = useCase.execute({
+        category: CardCompanyCategory.ONLINE,
+      });
+
+      expect(companies.length).toBeGreaterThan(0);
+      expect(
+        companies.every(
+          (company) => company.category === CardCompanyCategory.ONLINE,
+        ),
+      ).toBe(true);
+    });
+
+    it('should search companies by name', () => {
+      const companies = useCase.execute({
+        searchTerm: '三井住友',
+      });
+
+      expect(companies.length).toBeGreaterThan(0);
+      expect(
+        companies.some((company) => company.name.includes('三井住友')),
+      ).toBe(true);
+    });
+
+    it('should search companies by name (case insensitive)', () => {
+      const companiesUpper = useCase.execute({
+        searchTerm: 'JCB',
+      });
+      const companiesLower = useCase.execute({
+        searchTerm: 'jcb',
+      });
+
+      expect(companiesUpper.length).toBe(companiesLower.length);
+      expect(companiesUpper.length).toBeGreaterThan(0);
+    });
+
+    it('should search companies by code', () => {
+      const companies = useCase.execute({
+        searchTerm: 'SMBC',
+      });
+
+      expect(companies.length).toBeGreaterThan(0);
+      expect(companies.some((company) => company.code === 'SMBC')).toBe(true);
+    });
+
+    it('should combine category and search filters', () => {
+      const companies = useCase.execute({
+        category: CardCompanyCategory.MAJOR,
+        searchTerm: 'JCB',
+      });
+
+      expect(
+        companies.every(
+          (company) => company.category === CardCompanyCategory.MAJOR,
+        ),
+      ).toBe(true);
+      expect(companies.some((company) => company.code === 'JCB')).toBe(true);
+    });
+
+    it('should return empty array for non-existent search term', () => {
+      const companies = useCase.execute({
+        searchTerm: 'nonexistent-card-xyz',
+      });
+
+      expect(companies).toBeInstanceOf(Array);
+      expect(companies.length).toBe(0);
+    });
+
+    it('should include major card companies in the list', () => {
+      const companies = useCase.execute();
+      const companyNames = companies.map((company) => company.name);
+
+      // 大手カード会社が含まれていることを確認
+      expect(companyNames).toContain('三井住友カード');
+      expect(companyNames).toContain('JCB');
+    });
+
+    it('should include online card companies in the list', () => {
+      const companies = useCase.execute();
+      const companyNames = companies.map((company) => company.name);
+
+      // ネット系カードが含まれていることを確認
+      expect(companyNames).toContain('楽天カード');
+    });
+
+    it('should have unique company IDs', () => {
+      const companies = useCase.execute();
+      const ids = companies.map((company) => company.id);
+      const uniqueIds = new Set(ids);
+
+      expect(uniqueIds.size).toBe(ids.length);
+    });
+
+    it('should have unique company codes', () => {
+      const companies = useCase.execute();
+      const codes = companies.map((company) => company.code);
+      const uniqueCodes = new Set(codes);
+
+      expect(uniqueCodes.size).toBe(codes.length);
+    });
+  });
+
+  describe('findByCode', () => {
+    it('should find company by code', () => {
+      const company = useCase.findByCode('SMBC');
+
+      expect(company).toBeDefined();
+      expect(company?.code).toBe('SMBC');
+      expect(company?.name).toBe('三井住友カード');
+    });
+
+    it('should return null for non-existent code', () => {
+      const company = useCase.findByCode('XXXX');
+
+      expect(company).toBeNull();
+    });
+
+    it('should return null for unsupported company', () => {
+      // すべてのサポート済みカード会社が isSupported: true であることを想定
+      const company = useCase.findByCode('SMBC');
+
+      expect(company).not.toBeNull();
+      if (company) {
+        expect(company.isSupported).toBe(true);
+      }
+    });
+
+    it('should find test card company', () => {
+      const company = useCase.findByCode('TEST');
+
+      expect(company).toBeDefined();
+      expect(company?.code).toBe('TEST');
+      expect(company?.name).toBe('テストカード');
+    });
+  });
+});

--- a/apps/backend/src/modules/credit-card/application/use-cases/get-supported-card-companies.use-case.ts
+++ b/apps/backend/src/modules/credit-card/application/use-cases/get-supported-card-companies.use-case.ts
@@ -1,0 +1,48 @@
+import { Injectable } from '@nestjs/common';
+import { CardCompany, CardCompanyCategory } from '@account-book/types';
+import { SUPPORTED_CARD_COMPANIES } from '../../infrastructure/data/card-companies.data';
+
+export interface GetSupportedCardCompaniesQuery {
+  category?: CardCompanyCategory;
+  searchTerm?: string;
+}
+
+/**
+ * 対応カード会社一覧取得ユースケース
+ */
+@Injectable()
+export class GetSupportedCardCompaniesUseCase {
+  execute(query?: GetSupportedCardCompaniesQuery): CardCompany[] {
+    let companies = [...SUPPORTED_CARD_COMPANIES];
+
+    // カテゴリで絞り込み
+    if (query?.category) {
+      companies = companies.filter(
+        (company) => company.category === query.category,
+      );
+    }
+
+    // 検索キーワードで絞り込み
+    if (query?.searchTerm) {
+      const searchTerm = query.searchTerm.toLowerCase();
+      companies = companies.filter(
+        (company) =>
+          company.name.toLowerCase().includes(searchTerm) ||
+          company.code.toLowerCase().includes(searchTerm),
+      );
+    }
+
+    // サポート対象のみを返す
+    return companies.filter((company) => company.isSupported);
+  }
+
+  /**
+   * カード会社コードからカード会社情報を取得
+   */
+  findByCode(companyCode: string): CardCompany | null {
+    const company = SUPPORTED_CARD_COMPANIES.find(
+      (c) => c.code === companyCode,
+    );
+    return company && company.isSupported ? company : null;
+  }
+}

--- a/apps/backend/src/modules/credit-card/application/use-cases/test-credit-card-connection.use-case.spec.ts
+++ b/apps/backend/src/modules/credit-card/application/use-cases/test-credit-card-connection.use-case.spec.ts
@@ -1,0 +1,207 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { TestCreditCardConnectionUseCase } from './test-credit-card-connection.use-case';
+import { CREDIT_CARD_API_CLIENT } from '../../credit-card.tokens';
+import type { ICreditCardAPIClient } from '../../infrastructure/adapters/credit-card-api.adapter.interface';
+
+describe('TestCreditCardConnectionUseCase', () => {
+  let useCase: TestCreditCardConnectionUseCase;
+  let mockAPIClient: jest.Mocked<ICreditCardAPIClient>;
+
+  beforeEach(async () => {
+    mockAPIClient = {
+      testConnection: jest.fn(),
+      getCardInfo: jest.fn(),
+      getTransactions: jest.fn(),
+      getPaymentInfo: jest.fn(),
+      mapToTransactionEntity: jest.fn(),
+      mapToPaymentVO: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TestCreditCardConnectionUseCase,
+        {
+          provide: CREDIT_CARD_API_CLIENT,
+          useValue: mockAPIClient,
+        },
+      ],
+    }).compile();
+
+    module.useLogger(false);
+
+    useCase = module.get<TestCreditCardConnectionUseCase>(
+      TestCreditCardConnectionUseCase,
+    );
+  });
+
+  it('should be defined', () => {
+    expect(useCase).toBeDefined();
+  });
+
+  describe('execute', () => {
+    const mockDto = {
+      cardNumber: '1234567890123456',
+      cardHolderName: 'TARO YAMADA',
+      expiryDate: '2025-12-31',
+      username: 'test@example.com',
+      password: 'password123',
+      issuer: 'テストカード',
+      apiKey: 'test-api-key',
+    };
+
+    it('should return success result when connection test succeeds', async () => {
+      // Arrange
+      const mockCardInfo = {
+        cardNumber: '3456',
+        creditLimit: 500000,
+        currentBalance: 125000,
+        availableCredit: 375000,
+      };
+
+      mockAPIClient.testConnection.mockResolvedValue({ success: true });
+      mockAPIClient.getCardInfo.mockResolvedValue(mockCardInfo);
+
+      // Act
+      const result = await useCase.execute(mockDto);
+
+      // Assert
+      expect(result.success).toBe(true);
+      expect(result.message).toBe('接続に成功しました');
+      expect(result.cardInfo).toBeDefined();
+      expect(result.cardInfo?.cardName).toBe('テストカード');
+      expect(result.cardInfo?.cardNumber).toBe('3456');
+      expect(result.cardInfo?.cardHolderName).toBe('TARO YAMADA');
+      expect(result.cardInfo?.expiryDate).toBe('2025-12-31');
+      expect(result.cardInfo?.issuer).toBe('テストカード');
+      expect(result.errorCode).toBeUndefined();
+
+      expect(mockAPIClient.testConnection).toHaveBeenCalledWith({
+        cardNumber: '1234567890123456',
+        cardHolderName: 'TARO YAMADA',
+        expiryDate: '2025-12-31',
+        username: 'test@example.com',
+        password: 'password123',
+        apiKey: 'test-api-key',
+      });
+      expect(mockAPIClient.getCardInfo).toHaveBeenCalledWith({
+        cardNumber: '1234567890123456',
+        cardHolderName: 'TARO YAMADA',
+        expiryDate: '2025-12-31',
+        username: 'test@example.com',
+        password: 'password123',
+        apiKey: 'test-api-key',
+      });
+    });
+
+    it('should return success result when connection test succeeds without apiKey', async () => {
+      // Arrange
+      const dtoWithoutApiKey = {
+        ...mockDto,
+        apiKey: undefined,
+      };
+      const mockCardInfo = {
+        cardNumber: '3456',
+        creditLimit: 500000,
+        currentBalance: 125000,
+        availableCredit: 375000,
+      };
+
+      mockAPIClient.testConnection.mockResolvedValue({ success: true });
+      mockAPIClient.getCardInfo.mockResolvedValue(mockCardInfo);
+
+      // Act
+      const result = await useCase.execute(dtoWithoutApiKey);
+
+      // Assert
+      expect(result.success).toBe(true);
+      expect(result.message).toBe('接続に成功しました');
+      expect(result.cardInfo).toBeDefined();
+
+      expect(mockAPIClient.testConnection).toHaveBeenCalledWith({
+        cardNumber: '1234567890123456',
+        cardHolderName: 'TARO YAMADA',
+        expiryDate: '2025-12-31',
+        username: 'test@example.com',
+        password: 'password123',
+        apiKey: undefined,
+      });
+    });
+
+    it('should return failure result when connection test fails', async () => {
+      // Arrange
+      mockAPIClient.testConnection.mockResolvedValue({
+        success: false,
+        error: '認証に失敗しました',
+      });
+
+      // Act
+      const result = await useCase.execute(mockDto);
+
+      // Assert
+      expect(result.success).toBe(false);
+      expect(result.message).toBe('認証に失敗しました');
+      expect(result.errorCode).toBe('CC001');
+      expect(result.cardInfo).toBeUndefined();
+
+      expect(mockAPIClient.testConnection).toHaveBeenCalled();
+      expect(mockAPIClient.getCardInfo).not.toHaveBeenCalled();
+    });
+
+    it('should return failure result with default message when connection test fails without error message', async () => {
+      // Arrange
+      mockAPIClient.testConnection.mockResolvedValue({
+        success: false,
+      });
+
+      // Act
+      const result = await useCase.execute(mockDto);
+
+      // Assert
+      expect(result.success).toBe(false);
+      expect(result.message).toBe('接続テストに失敗しました');
+      expect(result.errorCode).toBe('CC001');
+      expect(result.cardInfo).toBeUndefined();
+    });
+
+    it('should return failure result when API client throws an error', async () => {
+      // Arrange
+      const error = new Error('Network error');
+      mockAPIClient.testConnection.mockRejectedValue(error);
+
+      // Act
+      const result = await useCase.execute(mockDto);
+
+      // Assert
+      expect(result.success).toBe(false);
+      expect(result.message).toBe(
+        '接続テストに失敗しました。管理者にお問い合わせください。',
+      );
+      expect(result.errorCode).toBe('CC002');
+      expect(result.cardInfo).toBeUndefined();
+
+      expect(mockAPIClient.testConnection).toHaveBeenCalled();
+      expect(mockAPIClient.getCardInfo).not.toHaveBeenCalled();
+    });
+
+    it('should return failure result when getCardInfo throws an error after successful connection test', async () => {
+      // Arrange
+      const error = new Error('Failed to get card info');
+      mockAPIClient.testConnection.mockResolvedValue({ success: true });
+      mockAPIClient.getCardInfo.mockRejectedValue(error);
+
+      // Act
+      const result = await useCase.execute(mockDto);
+
+      // Assert
+      expect(result.success).toBe(false);
+      expect(result.message).toBe(
+        '接続テストに失敗しました。管理者にお問い合わせください。',
+      );
+      expect(result.errorCode).toBe('CC002');
+      expect(result.cardInfo).toBeUndefined();
+
+      expect(mockAPIClient.testConnection).toHaveBeenCalled();
+      expect(mockAPIClient.getCardInfo).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/backend/src/modules/credit-card/application/use-cases/test-credit-card-connection.use-case.ts
+++ b/apps/backend/src/modules/credit-card/application/use-cases/test-credit-card-connection.use-case.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, Logger } from '@nestjs/common';
 import {
   CreditCardCredentials,
   CreditCardConnectionTestResult,
@@ -21,6 +21,8 @@ export interface TestCreditCardConnectionDto {
  */
 @Injectable()
 export class TestCreditCardConnectionUseCase {
+  private readonly logger = new Logger(TestCreditCardConnectionUseCase.name);
+
   constructor(
     @Inject(CREDIT_CARD_API_CLIENT)
     private readonly creditCardApiClient: ICreditCardAPIClient,
@@ -68,9 +70,15 @@ export class TestCreditCardConnectionUseCase {
       };
     } catch (error) {
       // エラーの場合は汎用エラー
+      // セキュリティ上の理由から、内部エラーメッセージはクライアントに返さない
+      // 詳細なエラーはサーバー側でロギングする
+      this.logger.error(
+        'クレジットカード接続テストでエラーが発生しました',
+        error,
+      );
       return {
         success: false,
-        message: `接続テストに失敗しました: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        message: '接続テストに失敗しました。管理者にお問い合わせください。',
         errorCode: 'CC002',
       };
     }

--- a/apps/backend/src/modules/credit-card/application/use-cases/test-credit-card-connection.use-case.ts
+++ b/apps/backend/src/modules/credit-card/application/use-cases/test-credit-card-connection.use-case.ts
@@ -1,0 +1,78 @@
+import { Inject, Injectable } from '@nestjs/common';
+import {
+  CreditCardCredentials,
+  CreditCardConnectionTestResult,
+} from '@account-book/types';
+import type { ICreditCardAPIClient } from '../../infrastructure/adapters/credit-card-api.adapter.interface';
+import { CREDIT_CARD_API_CLIENT } from '../../credit-card.tokens';
+
+export interface TestCreditCardConnectionDto {
+  cardNumber: string;
+  cardHolderName: string;
+  expiryDate: string;
+  username: string;
+  password: string;
+  issuer: string;
+  apiKey?: string;
+}
+
+/**
+ * クレジットカード接続テストユースケース
+ */
+@Injectable()
+export class TestCreditCardConnectionUseCase {
+  constructor(
+    @Inject(CREDIT_CARD_API_CLIENT)
+    private readonly creditCardApiClient: ICreditCardAPIClient,
+  ) {}
+
+  async execute(
+    dto: TestCreditCardConnectionDto,
+  ): Promise<CreditCardConnectionTestResult> {
+    try {
+      // DTOをCreditCardCredentialsに変換
+      const credentials: CreditCardCredentials = {
+        cardNumber: dto.cardNumber,
+        cardHolderName: dto.cardHolderName,
+        expiryDate: dto.expiryDate,
+        username: dto.username,
+        password: dto.password,
+        apiKey: dto.apiKey,
+      };
+
+      // クレジットカードAPIアダプターを使って接続テスト
+      const result = await this.creditCardApiClient.testConnection(credentials);
+
+      if (result.success) {
+        // 接続成功時はカード情報を取得
+        const cardInfo =
+          await this.creditCardApiClient.getCardInfo(credentials);
+
+        return {
+          success: true,
+          message: '接続に成功しました',
+          cardInfo: {
+            cardName: dto.issuer,
+            cardNumber: cardInfo.cardNumber, // 下4桁のみ
+            cardHolderName: dto.cardHolderName,
+            expiryDate: dto.expiryDate,
+            issuer: dto.issuer,
+          },
+        };
+      }
+
+      return {
+        success: false,
+        message: result.error || '接続テストに失敗しました',
+        errorCode: 'CC001',
+      };
+    } catch (error) {
+      // エラーの場合は汎用エラー
+      return {
+        success: false,
+        message: `接続テストに失敗しました: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        errorCode: 'CC002',
+      };
+    }
+  }
+}

--- a/apps/backend/src/modules/credit-card/credit-card.module.ts
+++ b/apps/backend/src/modules/credit-card/credit-card.module.ts
@@ -10,6 +10,8 @@ import { ConnectCreditCardUseCase } from './application/use-cases/connect-credit
 import { FetchCreditCardTransactionsUseCase } from './application/use-cases/fetch-credit-card-transactions.use-case';
 import { FetchPaymentInfoUseCase } from './application/use-cases/fetch-payment-info.use-case';
 import { RefreshCreditCardDataUseCase } from './application/use-cases/refresh-credit-card-data.use-case';
+import { GetSupportedCardCompaniesUseCase } from './application/use-cases/get-supported-card-companies.use-case';
+import { TestCreditCardConnectionUseCase } from './application/use-cases/test-credit-card-connection.use-case';
 
 // Repositories
 import {
@@ -46,6 +48,8 @@ import { CRYPTO_SERVICE } from '../institution/institution.tokens';
     FetchCreditCardTransactionsUseCase,
     FetchPaymentInfoUseCase,
     RefreshCreditCardDataUseCase,
+    GetSupportedCardCompaniesUseCase,
+    TestCreditCardConnectionUseCase,
 
     // Repositories - TypeORM版を使用（JSON版は予備として残す）
     {

--- a/apps/backend/src/modules/credit-card/infrastructure/adapters/mock-credit-card-api.adapter.ts
+++ b/apps/backend/src/modules/credit-card/infrastructure/adapters/mock-credit-card-api.adapter.ts
@@ -54,7 +54,7 @@ export class MockCreditCardAPIAdapter implements ICreditCardAPIClient {
     };
   }
 
-  async getCardInfo(): Promise<CardInfo> {
+  async getCardInfo(_credentials: Record<string, unknown>): Promise<CardInfo> {
     await this.simulateNetworkDelay();
 
     return {

--- a/apps/backend/src/modules/credit-card/infrastructure/data/card-companies.data.ts
+++ b/apps/backend/src/modules/credit-card/infrastructure/data/card-companies.data.ts
@@ -1,0 +1,108 @@
+import { CardCompany, CardCompanyCategory } from '@account-book/types';
+
+/**
+ * 対応カード会社マスターデータ
+ * 実際のプロジェクトでは、外部ファイルやデータベースから読み込むことを推奨
+ */
+export const SUPPORTED_CARD_COMPANIES: CardCompany[] = [
+  // 大手カード会社
+  {
+    id: 'card_smbc',
+    code: 'SMBC',
+    name: '三井住友カード',
+    category: CardCompanyCategory.MAJOR,
+    isSupported: true,
+  },
+  {
+    id: 'card_jcb',
+    code: 'JCB',
+    name: 'JCB',
+    category: CardCompanyCategory.MAJOR,
+    isSupported: true,
+  },
+  {
+    id: 'card_uc',
+    code: 'UC',
+    name: 'ユーシーカード',
+    category: CardCompanyCategory.MAJOR,
+    isSupported: true,
+  },
+  {
+    id: 'card_dc',
+    code: 'DC',
+    name: 'ダイナースクラブ',
+    category: CardCompanyCategory.MAJOR,
+    isSupported: true,
+  },
+
+  // 銀行系カード
+  {
+    id: 'card_mufg',
+    code: 'MUFG',
+    name: '三菱UFJニコス',
+    category: CardCompanyCategory.BANK,
+    isSupported: true,
+  },
+  {
+    id: 'card_mizuho',
+    code: 'MIZUHO',
+    name: 'みずほカード',
+    category: CardCompanyCategory.BANK,
+    isSupported: true,
+  },
+  {
+    id: 'card_resona',
+    code: 'RESONA',
+    name: 'りそなカード',
+    category: CardCompanyCategory.BANK,
+    isSupported: true,
+  },
+
+  // 流通系カード
+  {
+    id: 'card_aeon',
+    code: 'AEON',
+    name: 'イオンカード',
+    category: CardCompanyCategory.RETAIL,
+    isSupported: true,
+  },
+  {
+    id: 'card_seven',
+    code: 'SEVEN',
+    name: 'セブンカード',
+    category: CardCompanyCategory.RETAIL,
+    isSupported: true,
+  },
+
+  // ネット系カード
+  {
+    id: 'card_rakuten',
+    code: 'RAKUTEN',
+    name: '楽天カード',
+    category: CardCompanyCategory.ONLINE,
+    isSupported: true,
+  },
+  {
+    id: 'card_amazon',
+    code: 'AMAZON',
+    name: 'Amazonカード',
+    category: CardCompanyCategory.ONLINE,
+    isSupported: true,
+  },
+  {
+    id: 'card_yahoo',
+    code: 'YAHOO',
+    name: 'Yahoo!カード',
+    category: CardCompanyCategory.ONLINE,
+    isSupported: true,
+  },
+
+  // テスト用カード会社
+  {
+    id: 'card_test',
+    code: 'TEST',
+    name: 'テストカード',
+    category: CardCompanyCategory.ONLINE,
+    isSupported: true,
+  },
+];

--- a/apps/backend/src/modules/credit-card/presentation/controllers/credit-card.controller.spec.ts
+++ b/apps/backend/src/modules/credit-card/presentation/controllers/credit-card.controller.spec.ts
@@ -15,6 +15,8 @@ describe('CreditCardController', () => {
   let connectUseCase: jest.Mocked<ConnectCreditCardUseCase>;
   let fetchPaymentInfoUseCase: jest.Mocked<FetchPaymentInfoUseCase>;
   let refreshUseCase: jest.Mocked<RefreshCreditCardDataUseCase>;
+  let getSupportedCardCompaniesUseCase: jest.Mocked<GetSupportedCardCompaniesUseCase>;
+  let testCreditCardConnectionUseCase: jest.Mocked<TestCreditCardConnectionUseCase>;
   let creditCardRepository: any;
 
   const mockCredentials = new EncryptedCredentials(
@@ -68,7 +70,7 @@ describe('CreditCardController', () => {
         },
         {
           provide: GetSupportedCardCompaniesUseCase,
-          useValue: { execute: jest.fn() },
+          useValue: { execute: jest.fn(), findByCode: jest.fn() },
         },
         {
           provide: TestCreditCardConnectionUseCase,
@@ -87,6 +89,12 @@ describe('CreditCardController', () => {
     connectUseCase = module.get(ConnectCreditCardUseCase);
     fetchPaymentInfoUseCase = module.get(FetchPaymentInfoUseCase);
     refreshUseCase = module.get(RefreshCreditCardDataUseCase);
+    getSupportedCardCompaniesUseCase = module.get(
+      GetSupportedCardCompaniesUseCase,
+    );
+    testCreditCardConnectionUseCase = module.get(
+      TestCreditCardConnectionUseCase,
+    );
   });
 
   describe('connect', () => {
@@ -165,6 +173,199 @@ describe('CreditCardController', () => {
       const result = await controller.refresh('card_1');
 
       expect(result.success).toBe(true);
+    });
+  });
+
+  describe('getSupportedCardCompanies', () => {
+    it('should return all supported card companies when no query is provided', () => {
+      const mockCompanies = [
+        {
+          id: 'card_1',
+          code: 'SMBC',
+          name: '三井住友カード',
+          category: 'major',
+          isSupported: true,
+        },
+        {
+          id: 'card_2',
+          code: 'JCB',
+          name: 'JCB',
+          category: 'major',
+          isSupported: true,
+        },
+      ];
+
+      getSupportedCardCompaniesUseCase.execute.mockReturnValue(mockCompanies);
+
+      const result = controller.getSupportedCardCompanies({});
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual(mockCompanies);
+      expect(result.count).toBe(2);
+      expect(getSupportedCardCompaniesUseCase.execute).toHaveBeenCalledWith({});
+    });
+
+    it('should filter card companies by category', () => {
+      const mockCompanies = [
+        {
+          id: 'card_1',
+          code: 'SMBC',
+          name: '三井住友カード',
+          category: 'major',
+          isSupported: true,
+        },
+      ];
+
+      getSupportedCardCompaniesUseCase.execute.mockReturnValue(mockCompanies);
+
+      const result = controller.getSupportedCardCompanies({
+        category: 'major',
+      } as any);
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual(mockCompanies);
+      expect(result.count).toBe(1);
+      expect(getSupportedCardCompaniesUseCase.execute).toHaveBeenCalledWith({
+        category: 'major',
+      });
+    });
+
+    it('should filter card companies by search term', () => {
+      const mockCompanies = [
+        {
+          id: 'card_1',
+          code: 'SMBC',
+          name: '三井住友カード',
+          category: 'major',
+          isSupported: true,
+        },
+      ];
+
+      getSupportedCardCompaniesUseCase.execute.mockReturnValue(mockCompanies);
+
+      const result = controller.getSupportedCardCompanies({
+        searchTerm: '三井住友',
+      } as any);
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual(mockCompanies);
+      expect(result.count).toBe(1);
+      expect(getSupportedCardCompaniesUseCase.execute).toHaveBeenCalledWith({
+        searchTerm: '三井住友',
+      });
+    });
+
+    it('should combine category and search term filters', () => {
+      const mockCompanies: any[] = [];
+
+      getSupportedCardCompaniesUseCase.execute.mockReturnValue(mockCompanies);
+
+      const result = controller.getSupportedCardCompanies({
+        category: 'major',
+        searchTerm: 'JCB',
+      } as any);
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual(mockCompanies);
+      expect(result.count).toBe(0);
+      expect(getSupportedCardCompaniesUseCase.execute).toHaveBeenCalledWith({
+        category: 'major',
+        searchTerm: 'JCB',
+      });
+    });
+  });
+
+  describe('testCreditCardConnection', () => {
+    it('should return success result when connection test succeeds', async () => {
+      const mockDto = {
+        cardName: 'Test Card',
+        cardNumber: '1234567890123456',
+        cardHolderName: 'TARO YAMADA',
+        expiryDate: '2025-12-31',
+        username: 'test@example.com',
+        password: 'password123',
+        issuer: 'テストカード',
+        paymentDay: 15,
+        closingDay: 10,
+        apiKey: 'test-api-key',
+      };
+
+      const mockResult = {
+        success: true,
+        message: '接続に成功しました',
+        cardInfo: {
+          cardName: 'テストカード',
+          cardNumber: '3456',
+          cardHolderName: 'TARO YAMADA',
+          expiryDate: '2025-12-31',
+          issuer: 'テストカード',
+        },
+      };
+
+      testCreditCardConnectionUseCase.execute.mockResolvedValue(
+        mockResult as any,
+      );
+
+      const result = await controller.testCreditCardConnection(mockDto as any);
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual(mockResult);
+      expect(testCreditCardConnectionUseCase.execute).toHaveBeenCalledWith(
+        mockDto,
+      );
+    });
+
+    it('should return failure result when connection test fails', async () => {
+      const mockDto = {
+        cardName: 'Test Card',
+        cardNumber: '1234567890123456',
+        cardHolderName: 'TARO YAMADA',
+        expiryDate: '2025-12-31',
+        username: 'test@example.com',
+        password: 'password123',
+        issuer: 'テストカード',
+        paymentDay: 15,
+        closingDay: 10,
+      };
+
+      const mockResult = {
+        success: false,
+        message: '認証に失敗しました',
+        errorCode: 'CC001',
+      };
+
+      testCreditCardConnectionUseCase.execute.mockResolvedValue(
+        mockResult as any,
+      );
+
+      const result = await controller.testCreditCardConnection(mockDto as any);
+
+      expect(result.success).toBe(true); // Controller層では常にsuccess: trueを返す
+      expect(result.data).toEqual(mockResult);
+      expect(testCreditCardConnectionUseCase.execute).toHaveBeenCalledWith(
+        mockDto,
+      );
+    });
+
+    it('should handle error when use case throws an exception', async () => {
+      const mockDto = {
+        cardName: 'Test Card',
+        cardNumber: '1234567890123456',
+        cardHolderName: 'TARO YAMADA',
+        expiryDate: '2025-12-31',
+        username: 'test@example.com',
+        password: 'password123',
+        issuer: 'テストカード',
+        paymentDay: 15,
+        closingDay: 10,
+      };
+
+      const error = new Error('Unexpected error');
+      testCreditCardConnectionUseCase.execute.mockRejectedValue(error);
+
+      await expect(
+        controller.testCreditCardConnection(mockDto as any),
+      ).rejects.toThrow('Unexpected error');
     });
   });
 });

--- a/apps/backend/src/modules/credit-card/presentation/controllers/credit-card.controller.spec.ts
+++ b/apps/backend/src/modules/credit-card/presentation/controllers/credit-card.controller.spec.ts
@@ -4,6 +4,8 @@ import { ConnectCreditCardUseCase } from '../../application/use-cases/connect-cr
 import { FetchCreditCardTransactionsUseCase } from '../../application/use-cases/fetch-credit-card-transactions.use-case';
 import { FetchPaymentInfoUseCase } from '../../application/use-cases/fetch-payment-info.use-case';
 import { RefreshCreditCardDataUseCase } from '../../application/use-cases/refresh-credit-card-data.use-case';
+import { GetSupportedCardCompaniesUseCase } from '../../application/use-cases/get-supported-card-companies.use-case';
+import { TestCreditCardConnectionUseCase } from '../../application/use-cases/test-credit-card-connection.use-case';
 import { CreditCardEntity } from '../../domain/entities/credit-card.entity';
 import { EncryptedCredentials } from '../../../institution/domain/value-objects/encrypted-credentials.vo';
 import { CREDIT_CARD_REPOSITORY } from '../../credit-card.tokens';
@@ -62,6 +64,14 @@ describe('CreditCardController', () => {
         },
         {
           provide: RefreshCreditCardDataUseCase,
+          useValue: { execute: jest.fn() },
+        },
+        {
+          provide: GetSupportedCardCompaniesUseCase,
+          useValue: { execute: jest.fn() },
+        },
+        {
+          provide: TestCreditCardConnectionUseCase,
           useValue: { execute: jest.fn() },
         },
         {

--- a/apps/backend/src/modules/credit-card/presentation/controllers/credit-card.controller.ts
+++ b/apps/backend/src/modules/credit-card/presentation/controllers/credit-card.controller.ts
@@ -27,6 +27,10 @@ import { CREDIT_CARD_REPOSITORY } from '../../credit-card.tokens';
 import { CreditCardJSONResponse } from '../../domain/entities/credit-card.entity';
 import { CreditCardTransactionJSONResponse } from '../../domain/entities/credit-card-transaction.entity';
 import { PaymentJSONResponse } from '../../domain/value-objects/payment.vo';
+import {
+  CardCompany,
+  CreditCardConnectionTestResult,
+} from '@account-book/types';
 
 @Controller('api/credit-cards')
 export class CreditCardController {
@@ -50,7 +54,7 @@ export class CreditCardController {
     @Query() query: GetSupportedCardCompaniesQueryDto,
   ): {
     success: boolean;
-    data: unknown[];
+    data: CardCompany[];
     count: number;
   } {
     const companies = this.getSupportedCardCompaniesUseCase.execute(query);
@@ -72,15 +76,13 @@ export class CreditCardController {
     @Body() dto: TestCreditCardConnectionDto,
   ): Promise<{
     success: boolean;
-    data: Record<string, unknown>;
+    data: CreditCardConnectionTestResult;
   }> {
     const result = await this.testCreditCardConnectionUseCase.execute(dto);
 
-    // レスポンスの冗長性を解消: successはトップレベルのみ
-    const { success, ...data } = result;
     return {
-      success,
-      data,
+      success: true,
+      data: result,
     };
   }
 

--- a/apps/backend/src/modules/credit-card/presentation/dto/get-supported-card-companies.dto.ts
+++ b/apps/backend/src/modules/credit-card/presentation/dto/get-supported-card-companies.dto.ts
@@ -1,0 +1,17 @@
+import { IsEnum, IsOptional, IsString } from 'class-validator';
+import { CardCompanyCategory } from '@account-book/types';
+
+/**
+ * 対応カード会社一覧取得クエリDTO
+ */
+export class GetSupportedCardCompaniesQueryDto {
+  @IsOptional()
+  @IsEnum(CardCompanyCategory, {
+    message: 'カード会社カテゴリは有効な値を指定してください',
+  })
+  category?: CardCompanyCategory;
+
+  @IsOptional()
+  @IsString({ message: '検索キーワードは文字列で指定してください' })
+  searchTerm?: string;
+}

--- a/apps/backend/src/modules/credit-card/presentation/dto/test-credit-card-connection.dto.ts
+++ b/apps/backend/src/modules/credit-card/presentation/dto/test-credit-card-connection.dto.ts
@@ -1,0 +1,62 @@
+import {
+  IsString,
+  IsNotEmpty,
+  IsDateString,
+  IsOptional,
+  Length,
+  Matches,
+} from 'class-validator';
+
+/**
+ * クレジットカード接続テストリクエストDTO
+ */
+export class TestCreditCardConnectionDto {
+  @IsString({ message: 'カード番号は文字列で指定してください' })
+  @IsNotEmpty({ message: 'カード番号は必須です' })
+  @Matches(/^\d{16}$/, {
+    message: 'カード番号は16桁の数字で指定してください',
+  })
+  cardNumber!: string;
+
+  @IsString({ message: 'カード名義は文字列で指定してください' })
+  @IsNotEmpty({ message: 'カード名義は必須です' })
+  @Length(1, 100, {
+    message: 'カード名義は1文字以上100文字以下で指定してください',
+  })
+  cardHolderName!: string;
+
+  @IsDateString(
+    {},
+    { message: '有効期限は有効な日付形式（YYYY-MM-DD）で指定してください' },
+  )
+  @IsNotEmpty({ message: '有効期限は必須です' })
+  expiryDate!: string;
+
+  @IsString({ message: 'ログインIDは文字列で指定してください' })
+  @IsNotEmpty({ message: 'ログインIDは必須です' })
+  @Length(1, 255, {
+    message: 'ログインIDは1文字以上255文字以下で指定してください',
+  })
+  username!: string;
+
+  @IsString({ message: 'パスワードは文字列で指定してください' })
+  @IsNotEmpty({ message: 'パスワードは必須です' })
+  @Length(8, 100, {
+    message: 'パスワードは8文字以上100文字以下で指定してください',
+  })
+  password!: string;
+
+  @IsString({ message: '発行会社は文字列で指定してください' })
+  @IsNotEmpty({ message: '発行会社は必須です' })
+  @Length(1, 100, {
+    message: '発行会社は1文字以上100文字以下で指定してください',
+  })
+  issuer!: string;
+
+  @IsOptional()
+  @IsString({ message: 'API認証キーは文字列で指定してください' })
+  @Length(1, 255, {
+    message: 'API認証キーは1文字以上255文字以下で指定してください',
+  })
+  apiKey?: string;
+}

--- a/apps/frontend/src/app/credit-cards/add/page.tsx
+++ b/apps/frontend/src/app/credit-cards/add/page.tsx
@@ -1,0 +1,253 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import toast from 'react-hot-toast';
+import { CardCompany, CreditCardConnectionTestResult } from '@account-book/types';
+import { CardCompanySelector } from '@/components/forms/CardCompanySelector';
+import {
+  CreditCardCredentialsForm,
+  CreditCardCredentialsData,
+} from '@/components/forms/CreditCardCredentialsForm';
+import { ConnectionTestResult } from '@/components/forms/ConnectionTestResult';
+import { testCreditCardConnection, connectCreditCard } from '@/lib/api/credit-cards';
+import { ApiError } from '@/lib/api/client';
+import { getErrorMessage } from '@/utils/error.utils';
+
+type Step = 'select' | 'credentials' | 'result';
+
+/**
+ * クレジットカード追加ページ
+ */
+export default function AddCreditCardPage(): React.JSX.Element {
+  const router = useRouter();
+  const [currentStep, setCurrentStep] = useState<Step>('select');
+  const [selectedCompany, setSelectedCompany] = useState<CardCompany | null>(null);
+  const [testResult, setTestResult] = useState<CreditCardConnectionTestResult | null>(null);
+  const [credentials, setCredentials] = useState<CreditCardCredentialsData | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  // カード会社選択
+  const handleSelectCompany = (company: CardCompany): void => {
+    setSelectedCompany(company);
+    setCurrentStep('credentials');
+  };
+
+  // 接続テスト実行
+  const handleTestConnection = async (
+    credentialsData: CreditCardCredentialsData
+  ): Promise<void> => {
+    setLoading(true);
+    setCredentials(credentialsData);
+
+    try {
+      const result = await testCreditCardConnection({
+        cardNumber: credentialsData.cardNumber,
+        cardHolderName: credentialsData.cardHolderName,
+        expiryDate: credentialsData.expiryDate,
+        username: credentialsData.username,
+        password: credentialsData.password,
+        issuer: credentialsData.issuer,
+        apiKey: credentialsData.apiKey,
+      });
+
+      setTestResult(result);
+      setCurrentStep('result');
+    } catch (_error) {
+      setTestResult({
+        success: false,
+        message: '接続テストに失敗しました。しばらくしてから再度お試しください。',
+      });
+      setCurrentStep('result');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // クレジットカードを登録
+  const handleRegisterCard = async (): Promise<void> => {
+    if (!selectedCompany || !credentials) return;
+
+    setLoading(true);
+    setSaveError(null); // エラーをクリア
+
+    const DEFAULT_SAVE_ERROR_MESSAGE =
+      'クレジットカードの登録に失敗しました。もう一度お試しください。';
+
+    try {
+      // カード番号の下4桁のみを取得
+      const last4Digits = credentials.cardNumber.slice(-4);
+
+      await connectCreditCard({
+        cardName: selectedCompany.name,
+        cardNumber: last4Digits,
+        cardHolderName: credentials.cardHolderName,
+        expiryDate: credentials.expiryDate,
+        username: credentials.username,
+        password: credentials.password,
+        issuer: credentials.issuer,
+        paymentDay: credentials.paymentDay,
+        closingDay: credentials.closingDay,
+      });
+
+      // 成功時のトースト通知
+      toast.success(`${selectedCompany.name}を登録しました`, {
+        duration: 3000,
+        position: 'top-right',
+      });
+
+      // 成功したらクレジットカード管理画面に遷移
+      router.push('/credit-cards');
+    } catch (error) {
+      // ApiErrorの詳細を取得して表示
+      if (error instanceof ApiError) {
+        const errorMessage = error.message || DEFAULT_SAVE_ERROR_MESSAGE;
+        const details = error.details
+          ?.map((detail) => `${detail.field ? `${detail.field}: ` : ''}${detail.message}`)
+          .join(', ');
+        setSaveError(details || errorMessage);
+      } else {
+        const errorMessage = getErrorMessage(error, DEFAULT_SAVE_ERROR_MESSAGE);
+        setSaveError(errorMessage);
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // 再試行（認証情報入力に戻る）
+  const handleRetry = (): void => {
+    setCurrentStep('credentials');
+    setTestResult(null);
+  };
+
+  // カード会社選択に戻る
+  const handleBackToSelect = (): void => {
+    setCurrentStep('select');
+    setSelectedCompany(null);
+    setTestResult(null);
+    setCredentials(null);
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-8">
+      <div className="max-w-4xl mx-auto px-4">
+        {/* ヘッダー */}
+        <div className="mb-8">
+          <button
+            onClick={() => router.back()}
+            className="text-blue-600 hover:text-blue-800 mb-4 flex items-center"
+          >
+            <svg className="w-5 h-5 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M15 19l-7-7 7-7"
+              />
+            </svg>
+            戻る
+          </button>
+          <h1 className="text-3xl font-bold text-gray-900">クレジットカードを追加</h1>
+          <p className="mt-2 text-gray-600">
+            クレジットカードを連携して、自動で利用明細を取得します
+          </p>
+        </div>
+
+        {/* ステップインジケーター */}
+        <div className="mb-8">
+          <div className="flex items-center justify-between">
+            <div className="flex-1">
+              <div
+                className={`w-full h-2 rounded ${
+                  currentStep === 'select' ? 'bg-blue-600' : 'bg-blue-200'
+                }`}
+              ></div>
+              <div className="mt-2 text-sm font-medium text-gray-900">1. カード会社選択</div>
+            </div>
+            <div className="w-8"></div>
+            <div className="flex-1">
+              <div
+                className={`w-full h-2 rounded ${
+                  currentStep === 'credentials' || currentStep === 'result'
+                    ? 'bg-blue-600'
+                    : 'bg-gray-300'
+                }`}
+              ></div>
+              <div className="mt-2 text-sm font-medium text-gray-900">2. 認証情報入力</div>
+            </div>
+            <div className="w-8"></div>
+            <div className="flex-1">
+              <div
+                className={`w-full h-2 rounded ${
+                  currentStep === 'result' ? 'bg-blue-600' : 'bg-gray-300'
+                }`}
+              ></div>
+              <div className="mt-2 text-sm font-medium text-gray-900">3. 接続テスト</div>
+            </div>
+          </div>
+        </div>
+
+        {/* コンテンツ */}
+        <div className="bg-white rounded-lg shadow p-6">
+          {currentStep === 'select' && (
+            <CardCompanySelector
+              onSelectCompany={handleSelectCompany}
+              selectedCompany={selectedCompany || undefined}
+            />
+          )}
+
+          {currentStep === 'credentials' && selectedCompany && (
+            <div>
+              <button
+                onClick={handleBackToSelect}
+                className="text-blue-600 hover:text-blue-800 mb-4"
+              >
+                ← カード会社を変更
+              </button>
+              <CreditCardCredentialsForm
+                company={selectedCompany}
+                onSubmit={handleTestConnection}
+                loading={loading}
+              />
+            </div>
+          )}
+
+          {currentStep === 'result' && testResult && (
+            <div>
+              {saveError && (
+                <div className="mb-4 bg-red-50 border border-red-200 rounded-lg p-4">
+                  <div className="flex">
+                    <div className="flex-shrink-0">
+                      <svg
+                        className="h-5 w-5 text-red-400"
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 20 20"
+                        fill="currentColor"
+                      >
+                        <path
+                          fillRule="evenodd"
+                          d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z"
+                          clipRule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                    <div className="ml-3">
+                      <p className="text-sm text-red-800">{saveError}</p>
+                    </div>
+                  </div>
+                </div>
+              )}
+              <ConnectionTestResult
+                result={testResult}
+                onRetry={handleRetry}
+                onContinue={testResult.success ? handleRegisterCard : undefined}
+              />
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/credit-cards/add/page.tsx
+++ b/apps/frontend/src/app/credit-cards/add/page.tsx
@@ -54,10 +54,17 @@ export default function AddCreditCardPage(): React.JSX.Element {
 
       setTestResult(result);
       setCurrentStep('result');
-    } catch (_error) {
+    } catch (error) {
+      const message =
+        error instanceof ApiError
+          ? error.message
+          : '接続テストに失敗しました。しばらくしてから再度お試しください。';
+      const errorCode = error instanceof ApiError ? error.code : undefined;
+
       setTestResult({
         success: false,
-        message: '接続テストに失敗しました。しばらくしてから再度お試しください。',
+        message,
+        errorCode,
       });
       setCurrentStep('result');
     } finally {

--- a/apps/frontend/src/components/forms/CardCompanySelector.tsx
+++ b/apps/frontend/src/components/forms/CardCompanySelector.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { CardCompany, CardCompanyCategory } from '@account-book/types';
+import { getSupportedCardCompanies } from '@/lib/api/credit-cards';
+
+interface CardCompanySelectorProps {
+  onSelectCompany: (company: CardCompany) => void;
+  selectedCompany?: CardCompany;
+}
+
+const CATEGORY_LABELS: Record<CardCompanyCategory, string> = {
+  [CardCompanyCategory.MAJOR]: '大手カード',
+  [CardCompanyCategory.BANK]: '銀行系',
+  [CardCompanyCategory.RETAIL]: '流通系',
+  [CardCompanyCategory.ONLINE]: 'ネット系',
+};
+
+/**
+ * カード会社選択コンポーネント
+ */
+export function CardCompanySelector({
+  onSelectCompany,
+  selectedCompany,
+}: CardCompanySelectorProps): React.JSX.Element {
+  const [companies, setCompanies] = useState<CardCompany[]>([]);
+  const [filteredCompanies, setFilteredCompanies] = useState<CardCompany[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [selectedCategory, setSelectedCategory] = useState<CardCompanyCategory | 'all'>('all');
+
+  // カード会社一覧を取得
+  useEffect(() => {
+    const fetchCompanies = async (): Promise<void> => {
+      try {
+        setLoading(true);
+        const data = await getSupportedCardCompanies();
+        setCompanies(data);
+        setFilteredCompanies(data);
+        setError(null);
+      } catch (_err) {
+        setError('カード会社一覧の取得に失敗しました');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    void fetchCompanies();
+  }, []);
+
+  // 検索とフィルタリング
+  useEffect(() => {
+    let result = [...companies];
+
+    // カテゴリでフィルタ
+    if (selectedCategory !== 'all') {
+      result = result.filter((company) => company.category === selectedCategory);
+    }
+
+    // 検索キーワードでフィルタ
+    if (searchTerm) {
+      const term = searchTerm.toLowerCase();
+      result = result.filter(
+        (company) =>
+          company.name.toLowerCase().includes(term) || company.code.toLowerCase().includes(term)
+      );
+    }
+
+    setFilteredCompanies(result);
+  }, [companies, searchTerm, selectedCategory]);
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center py-8">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="bg-red-50 border border-red-200 text-red-800 px-4 py-3 rounded">{error}</div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* 検索ボックス */}
+      <div>
+        <input
+          type="text"
+          placeholder="カード会社名またはコードで検索"
+          value={searchTerm}
+          onChange={(e) => setSearchTerm(e.target.value)}
+          className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+        />
+      </div>
+
+      {/* カテゴリタブ */}
+      <div className="flex gap-2 border-b border-gray-200">
+        <button
+          onClick={() => setSelectedCategory('all')}
+          className={`px-4 py-2 font-medium ${
+            selectedCategory === 'all'
+              ? 'border-b-2 border-blue-600 text-blue-600'
+              : 'text-gray-600 hover:text-gray-900'
+          }`}
+        >
+          すべて
+        </button>
+        {(Object.entries(CATEGORY_LABELS) as [CardCompanyCategory, string][]).map(
+          ([category, label]) => (
+            <button
+              key={category}
+              onClick={() => setSelectedCategory(category)}
+              className={`px-4 py-2 font-medium ${
+                selectedCategory === category
+                  ? 'border-b-2 border-blue-600 text-blue-600'
+                  : 'text-gray-600 hover:text-gray-900'
+              }`}
+            >
+              {label}
+            </button>
+          )
+        )}
+      </div>
+
+      {/* カード会社一覧 */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3 max-h-96 overflow-y-auto">
+        {filteredCompanies.length === 0 ? (
+          <div className="col-span-2 text-center text-gray-500 py-8">
+            該当するカード会社が見つかりませんでした
+          </div>
+        ) : (
+          filteredCompanies.map((company) => (
+            <button
+              key={company.id}
+              onClick={() => onSelectCompany(company)}
+              className={`p-4 border rounded-lg text-left transition-colors ${
+                selectedCompany?.id === company.id
+                  ? 'border-blue-600 bg-blue-50'
+                  : 'border-gray-300 hover:border-blue-400 hover:bg-gray-50'
+              }`}
+            >
+              <div className="font-medium text-gray-900">{company.name}</div>
+              <div className="text-sm text-gray-500">コード: {company.code}</div>
+              <div className="text-xs text-gray-400 mt-1">{CATEGORY_LABELS[company.category]}</div>
+            </button>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/forms/ConnectionTestResult.tsx
+++ b/apps/frontend/src/components/forms/ConnectionTestResult.tsx
@@ -1,9 +1,11 @@
 'use client';
 
-import { BankConnectionTestResult } from '@account-book/types';
+import { BankConnectionTestResult, CreditCardConnectionTestResult } from '@account-book/types';
+
+type ConnectionTestResult = BankConnectionTestResult | CreditCardConnectionTestResult;
 
 interface ConnectionTestResultProps {
-  result: BankConnectionTestResult;
+  result: ConnectionTestResult;
   onRetry?: () => void;
   onContinue?: () => void;
 }
@@ -40,8 +42,8 @@ export function ConnectionTestResult({
           </div>
         </div>
 
-        {/* 口座情報 */}
-        {result.accountInfo && (
+        {/* 口座情報（銀行の場合） */}
+        {'accountInfo' in result && result.accountInfo && (
           <div className="bg-white border border-gray-200 rounded-lg p-6">
             <h4 className="text-sm font-medium text-gray-900 mb-4">取得した口座情報</h4>
             <dl className="grid grid-cols-1 gap-4">
@@ -79,13 +81,53 @@ export function ConnectionTestResult({
           </div>
         )}
 
+        {/* カード情報（クレジットカードの場合） */}
+        {'cardInfo' in result && result.cardInfo && (
+          <div className="bg-white border border-gray-200 rounded-lg p-6">
+            <h4 className="text-sm font-medium text-gray-900 mb-4">取得したカード情報</h4>
+            <dl className="grid grid-cols-1 gap-4">
+              <div>
+                <dt className="text-sm text-gray-500">カード名</dt>
+                <dd className="mt-1 text-sm font-medium text-gray-900">
+                  {result.cardInfo.cardName}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-sm text-gray-500">カード番号（下4桁）</dt>
+                <dd className="mt-1 text-sm font-medium text-gray-900">
+                  **** **** **** {result.cardInfo.cardNumber}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-sm text-gray-500">カード名義</dt>
+                <dd className="mt-1 text-sm font-medium text-gray-900">
+                  {result.cardInfo.cardHolderName}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-sm text-gray-500">有効期限</dt>
+                <dd className="mt-1 text-sm font-medium text-gray-900">
+                  {new Date(result.cardInfo.expiryDate).toLocaleDateString('ja-JP', {
+                    year: 'numeric',
+                    month: '2-digit',
+                  })}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-sm text-gray-500">発行会社</dt>
+                <dd className="mt-1 text-sm font-medium text-gray-900">{result.cardInfo.issuer}</dd>
+              </div>
+            </dl>
+          </div>
+        )}
+
         {/* アクションボタン */}
         {onContinue && (
           <button
             onClick={onContinue}
             className="w-full bg-blue-600 text-white py-3 px-4 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
           >
-            この銀行を登録する
+            {'accountInfo' in result ? 'この銀行を登録する' : 'このクレジットカードを登録する'}
           </button>
         )}
       </div>
@@ -148,6 +190,19 @@ export function ConnectionTestResult({
           {result.errorCode === 'BE005' && (
             <ul className="list-disc list-inside space-y-1">
               <li>時間をおいてから再度お試しください</li>
+            </ul>
+          )}
+          {result.errorCode === 'CC001' && (
+            <ul className="list-disc list-inside space-y-1">
+              <li>カード番号、カード名義、有効期限を確認してください</li>
+              <li>ログインID・パスワードが正しいか確認してください</li>
+              <li>Web明細サービスの登録状況を確認してください</li>
+            </ul>
+          )}
+          {result.errorCode === 'CC002' && (
+            <ul className="list-disc list-inside space-y-1">
+              <li>インターネット接続を確認してください</li>
+              <li>しばらく待ってから再度お試しください</li>
             </ul>
           )}
           {!result.errorCode && <p>しばらく待ってから再度お試しください</p>}

--- a/apps/frontend/src/components/forms/ConnectionTestResult.tsx
+++ b/apps/frontend/src/components/forms/ConnectionTestResult.tsx
@@ -107,10 +107,7 @@ export function ConnectionTestResult({
               <div>
                 <dt className="text-sm text-gray-500">有効期限</dt>
                 <dd className="mt-1 text-sm font-medium text-gray-900">
-                  {new Date(result.cardInfo.expiryDate).toLocaleDateString('ja-JP', {
-                    year: 'numeric',
-                    month: '2-digit',
-                  })}
+                  {result.cardInfo.expiryDate.substring(0, 7).replace('-', '/')}
                 </dd>
               </div>
               <div>

--- a/apps/frontend/src/components/forms/CreditCardCredentialsForm.tsx
+++ b/apps/frontend/src/components/forms/CreditCardCredentialsForm.tsx
@@ -1,0 +1,462 @@
+'use client';
+
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { CardCompany } from '@account-book/types';
+import { showErrorToast, ErrorModal } from '@/components/ui';
+import { useNotificationStore } from '@/stores/notification.store';
+
+interface CreditCardCredentialsFormProps {
+  company: CardCompany;
+  onSubmit: (credentials: CreditCardCredentialsData) => void;
+  loading?: boolean;
+  error?: string | null;
+  errorDetails?: string;
+}
+
+export interface CreditCardCredentialsData {
+  cardNumber: string; // 16桁
+  cardHolderName: string;
+  expiryDate: string; // YYYY-MM-DD形式
+  username: string;
+  password: string;
+  issuer: string;
+  apiKey?: string;
+  paymentDay: number;
+  closingDay: number;
+}
+
+/**
+ * クレジットカード認証情報入力フォーム
+ */
+export function CreditCardCredentialsForm({
+  company,
+  onSubmit,
+  loading = false,
+  error = null,
+  errorDetails,
+}: CreditCardCredentialsFormProps): React.JSX.Element {
+  const [formData, setFormData] = useState<CreditCardCredentialsData>({
+    cardNumber: '',
+    cardHolderName: '',
+    expiryDate: '',
+    username: '',
+    password: '',
+    issuer: company.name,
+    apiKey: '',
+    paymentDay: 10,
+    closingDay: 15,
+  });
+
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [showPassword, setShowPassword] = useState(false);
+  const [showErrorModal, setShowErrorModal] = useState(false);
+  const addNotification = useNotificationStore((state) => state.addNotification);
+  const prevErrorRef = useRef<string | null>(null);
+  const errorTimestampRef = useRef<Date | null>(null);
+  const formDataRef = useRef(formData);
+
+  // formDataRefを常に最新の状態に保つ
+  useEffect(() => {
+    formDataRef.current = formData;
+  }, [formData]);
+
+  // バリデーション
+  const validate = useCallback((dataToValidate: CreditCardCredentialsData): boolean => {
+    const newErrors: Record<string, string> = {};
+
+    // カード番号（16桁、Luhnアルゴリズム）
+    if (!/^\d{16}$/.test(dataToValidate.cardNumber)) {
+      newErrors.cardNumber = 'カード番号は16桁の数字で入力してください';
+    } else if (!luhnCheck(dataToValidate.cardNumber)) {
+      newErrors.cardNumber = 'カード番号が正しくありません';
+    }
+
+    // カード名義
+    if (!dataToValidate.cardHolderName.trim()) {
+      newErrors.cardHolderName = 'カード名義は必須です';
+    } else if (dataToValidate.cardHolderName.length > 100) {
+      newErrors.cardHolderName = 'カード名義は100文字以下で入力してください';
+    }
+
+    // 有効期限（未来日付）
+    if (!dataToValidate.expiryDate) {
+      newErrors.expiryDate = '有効期限は必須です';
+    } else {
+      const expiry = new Date(dataToValidate.expiryDate);
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+      if (expiry <= today) {
+        newErrors.expiryDate = '有効期限は未来の日付を入力してください';
+      }
+    }
+
+    // ログインID（メールアドレス形式）
+    if (!dataToValidate.username.trim()) {
+      newErrors.username = 'ログインIDは必須です';
+    } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(dataToValidate.username)) {
+      newErrors.username = 'ログインIDは有効なメールアドレス形式で入力してください';
+    }
+
+    // パスワード
+    if (!dataToValidate.password) {
+      newErrors.password = 'パスワードは必須です';
+    } else if (dataToValidate.password.length < 8) {
+      newErrors.password = 'パスワードは8文字以上で入力してください';
+    }
+
+    // 引落日
+    if (
+      !dataToValidate.paymentDay ||
+      dataToValidate.paymentDay < 1 ||
+      dataToValidate.paymentDay > 31
+    ) {
+      newErrors.paymentDay = '引落日は1〜31の範囲で入力してください';
+    }
+
+    // 締め日
+    if (
+      !dataToValidate.closingDay ||
+      dataToValidate.closingDay < 1 ||
+      dataToValidate.closingDay > 31
+    ) {
+      newErrors.closingDay = '締め日は1〜31の範囲で入力してください';
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  }, []);
+
+  // Luhnアルゴリズムによるカード番号検証
+  const luhnCheck = (cardNumber: string): boolean => {
+    let sum = 0;
+    let isEven = false;
+
+    for (let i = cardNumber.length - 1; i >= 0; i--) {
+      let digit = parseInt(cardNumber[i], 10);
+
+      if (isEven) {
+        digit *= 2;
+        if (digit > 9) {
+          digit -= 9;
+        }
+      }
+
+      sum += digit;
+      isEven = !isEven;
+    }
+
+    return sum % 10 === 0;
+  };
+
+  // エラー発生時の通知処理
+  const handleError = useCallback(
+    (errorMessage: string, details?: string): void => {
+      // エラー発生時刻を記録（初回のみ）
+      if (!errorTimestampRef.current) {
+        errorTimestampRef.current = new Date();
+      }
+
+      // Zustand storeに通知を追加
+      addNotification({
+        type: 'error',
+        message: errorMessage,
+        details,
+        institutionId: company.code,
+        retryable: true,
+      });
+
+      // トースト通知を表示
+      showErrorToast('error', errorMessage, {
+        details,
+        onRetry: () => {
+          // フォームを再送信（最新のformDataを使用）
+          if (validate(formDataRef.current)) {
+            onSubmit(formDataRef.current);
+          }
+        },
+        onShowDetails: () => {
+          setShowErrorModal(true);
+        },
+      });
+    },
+    [addNotification, company.code, onSubmit, validate]
+  );
+
+  // エラーがpropsで渡された場合の処理（useEffectで実行）
+  useEffect(() => {
+    if (error && error !== prevErrorRef.current) {
+      prevErrorRef.current = error;
+      handleError(error, errorDetails);
+    }
+  }, [error, errorDetails, handleError]);
+
+  const handleSubmit = (e: React.FormEvent): void => {
+    e.preventDefault();
+    if (validate(formData)) {
+      onSubmit(formData);
+    }
+  };
+
+  const handleChange = (field: keyof CreditCardCredentialsData, value: string | number): void => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+    // エラーをクリア
+    if (errors[field]) {
+      setErrors((prev) => {
+        const newErrors = { ...prev };
+        delete newErrors[field];
+        return newErrors;
+      });
+    }
+  };
+
+  // カード番号の入力フォーマット（4桁ごとにスペース）
+  const formatCardNumber = (value: string): string => {
+    const digits = value.replace(/\D/g, '');
+    return digits.slice(0, 16);
+  };
+
+  return (
+    <>
+      <form onSubmit={handleSubmit} className="space-y-6">
+        {/* 選択したカード会社の表示 */}
+        <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
+          <div className="text-sm text-gray-600">接続先カード会社</div>
+          <div className="text-lg font-medium text-gray-900">{company.name}</div>
+        </div>
+
+        {/* カード番号 */}
+        <div>
+          <label htmlFor="cardNumber" className="block text-sm font-medium text-gray-700 mb-2">
+            カード番号 <span className="text-red-500">*</span>
+          </label>
+          <input
+            id="cardNumber"
+            type="text"
+            value={formData.cardNumber}
+            onChange={(e) => {
+              const formatted = formatCardNumber(e.target.value);
+              handleChange('cardNumber', formatted);
+            }}
+            maxLength={16}
+            placeholder="1234567812345678"
+            className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+          <p className="mt-1 text-xs text-gray-500">16桁の数字で入力してください</p>
+          {errors.cardNumber && <p className="mt-1 text-sm text-red-600">{errors.cardNumber}</p>}
+        </div>
+
+        {/* カード名義 */}
+        <div>
+          <label htmlFor="cardHolderName" className="block text-sm font-medium text-gray-700 mb-2">
+            カード名義 <span className="text-red-500">*</span>
+          </label>
+          <input
+            id="cardHolderName"
+            type="text"
+            value={formData.cardHolderName}
+            onChange={(e) => handleChange('cardHolderName', e.target.value.toUpperCase())}
+            placeholder="TARO YAMADA"
+            className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+          <p className="mt-1 text-xs text-gray-500">
+            カード表面に記載されている名義を入力してください
+          </p>
+          {errors.cardHolderName && (
+            <p className="mt-1 text-sm text-red-600">{errors.cardHolderName}</p>
+          )}
+        </div>
+
+        {/* 有効期限 */}
+        <div>
+          <label htmlFor="expiryDate" className="block text-sm font-medium text-gray-700 mb-2">
+            有効期限 <span className="text-red-500">*</span>
+          </label>
+          <input
+            id="expiryDate"
+            type="date"
+            value={formData.expiryDate}
+            onChange={(e) => handleChange('expiryDate', e.target.value)}
+            min={new Date().toISOString().split('T')[0]}
+            className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+          <p className="mt-1 text-xs text-gray-500">
+            カード表面に記載されている有効期限を入力してください
+          </p>
+          {errors.expiryDate && <p className="mt-1 text-sm text-red-600">{errors.expiryDate}</p>}
+        </div>
+
+        {/* ログインID */}
+        <div>
+          <label htmlFor="username" className="block text-sm font-medium text-gray-700 mb-2">
+            ログインID <span className="text-red-500">*</span>
+          </label>
+          <input
+            id="username"
+            type="email"
+            value={formData.username}
+            onChange={(e) => handleChange('username', e.target.value)}
+            placeholder="user@example.com"
+            className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+          <p className="mt-1 text-xs text-gray-500">
+            Web明細サービスのログインID（メールアドレス）
+          </p>
+          {errors.username && <p className="mt-1 text-sm text-red-600">{errors.username}</p>}
+        </div>
+
+        {/* パスワード */}
+        <div>
+          <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-2">
+            パスワード <span className="text-red-500">*</span>
+          </label>
+          <div className="relative">
+            <input
+              id="password"
+              type={showPassword ? 'text' : 'password'}
+              value={formData.password}
+              onChange={(e) => handleChange('password', e.target.value)}
+              placeholder="Web明細サービスのパスワード"
+              className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+            <button
+              type="button"
+              onClick={() => setShowPassword(!showPassword)}
+              className="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-500 hover:text-gray-700"
+            >
+              {showPassword ? '非表示' : '表示'}
+            </button>
+          </div>
+          <p className="mt-1 text-xs text-gray-500">Web明細サービスのパスワード（8文字以上）</p>
+          {errors.password && <p className="mt-1 text-sm text-red-600">{errors.password}</p>}
+        </div>
+
+        {/* 引落日 */}
+        <div>
+          <label htmlFor="paymentDay" className="block text-sm font-medium text-gray-700 mb-2">
+            引落日 <span className="text-red-500">*</span>
+          </label>
+          <input
+            id="paymentDay"
+            type="number"
+            min="1"
+            max="31"
+            value={formData.paymentDay}
+            onChange={(e) => handleChange('paymentDay', parseInt(e.target.value, 10) || 0)}
+            className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+          <p className="mt-1 text-xs text-gray-500">毎月の引落日（1〜31）</p>
+          {errors.paymentDay && <p className="mt-1 text-sm text-red-600">{errors.paymentDay}</p>}
+        </div>
+
+        {/* 締め日 */}
+        <div>
+          <label htmlFor="closingDay" className="block text-sm font-medium text-gray-700 mb-2">
+            締め日 <span className="text-red-500">*</span>
+          </label>
+          <input
+            id="closingDay"
+            type="number"
+            min="1"
+            max="31"
+            value={formData.closingDay}
+            onChange={(e) => handleChange('closingDay', parseInt(e.target.value, 10) || 0)}
+            className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+          <p className="mt-1 text-xs text-gray-500">毎月の締め日（1〜31）</p>
+          {errors.closingDay && <p className="mt-1 text-sm text-red-600">{errors.closingDay}</p>}
+        </div>
+
+        {/* API認証キー（オプション） */}
+        <div>
+          <label htmlFor="apiKey" className="block text-sm font-medium text-gray-700 mb-2">
+            API認証キー（オプション）
+          </label>
+          <input
+            id="apiKey"
+            type="text"
+            value={formData.apiKey}
+            onChange={(e) => handleChange('apiKey', e.target.value)}
+            placeholder="カード会社から発行されたAPI認証キーを入力"
+            className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+          <p className="mt-1 text-xs text-gray-500">カード会社によっては必要な場合があります</p>
+        </div>
+
+        {/* 注意事項 */}
+        <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4">
+          <div className="flex">
+            <div className="flex-shrink-0">
+              <svg className="h-5 w-5 text-yellow-400" fill="currentColor" viewBox="0 0 20 20">
+                <path
+                  fillRule="evenodd"
+                  d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z"
+                  clipRule="evenodd"
+                />
+              </svg>
+            </div>
+            <div className="ml-3">
+              <h3 className="text-sm font-medium text-yellow-800">セキュリティに関する注意</h3>
+              <div className="mt-2 text-sm text-yellow-700">
+                <p>
+                  入力された認証情報は暗号化されて安全に保存されます。
+                  この情報はカード会社からデータを取得するためにのみ使用されます。
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* 送信ボタン */}
+        <button
+          type="submit"
+          disabled={loading}
+          className="w-full bg-blue-600 text-white py-3 px-4 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {loading ? (
+            <span className="flex items-center justify-center">
+              <svg
+                className="animate-spin -ml-1 mr-3 h-5 w-5 text-white"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+              >
+                <circle
+                  className="opacity-25"
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  strokeWidth="4"
+                ></circle>
+                <path
+                  className="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                ></path>
+              </svg>
+              接続テスト中...
+            </span>
+          ) : (
+            '接続テスト'
+          )}
+        </button>
+      </form>
+
+      {/* エラー詳細モーダル */}
+      <ErrorModal
+        isOpen={showErrorModal}
+        onClose={(): void => setShowErrorModal(false)}
+        type="error"
+        message={error || ''}
+        details={errorDetails}
+        institutionId={company.code}
+        timestamp={errorTimestampRef.current || undefined}
+        onRetry={(): void => {
+          if (validate(formDataRef.current)) {
+            onSubmit(formDataRef.current);
+          }
+        }}
+      />
+    </>
+  );
+}

--- a/apps/frontend/src/lib/api/credit-cards.ts
+++ b/apps/frontend/src/lib/api/credit-cards.ts
@@ -1,4 +1,11 @@
-import { CreditCard, CreditCardTransaction, Payment } from '@account-book/types';
+import {
+  CreditCard,
+  CreditCardTransaction,
+  Payment,
+  CardCompany,
+  CardCompanyCategory,
+  CreditCardConnectionTestResult,
+} from '@account-book/types';
 import { apiClient } from './client';
 
 /**
@@ -113,4 +120,50 @@ export async function refreshCreditCardData(id: string): Promise<{
     transactions: CreditCardTransaction[];
     payment: Payment;
   }>(`/credit-cards/${id}/refresh`, {});
+}
+
+export interface GetSupportedCardCompaniesParams {
+  category?: CardCompanyCategory;
+  searchTerm?: string;
+}
+
+export interface TestCreditCardConnectionRequest {
+  cardNumber: string;
+  cardHolderName: string;
+  expiryDate: string; // YYYY-MM-DD形式
+  username: string;
+  password: string;
+  issuer: string;
+  apiKey?: string;
+}
+
+/**
+ * 対応カード会社一覧を取得
+ */
+export async function getSupportedCardCompanies(
+  params?: GetSupportedCardCompaniesParams
+): Promise<CardCompany[]> {
+  const searchParams = new URLSearchParams();
+
+  if (params) {
+    if (params.category) searchParams.append('category', params.category);
+    if (params.searchTerm) searchParams.append('searchTerm', params.searchTerm);
+  }
+
+  const endpoint = `/credit-cards/companies/supported${
+    searchParams.toString() ? `?${searchParams.toString()}` : ''
+  }`;
+  return await apiClient.get<CardCompany[]>(endpoint);
+}
+
+/**
+ * クレジットカード接続テスト
+ */
+export async function testCreditCardConnection(
+  data: TestCreditCardConnectionRequest
+): Promise<CreditCardConnectionTestResult> {
+  return await apiClient.post<CreditCardConnectionTestResult>(
+    '/credit-cards/test-connection',
+    data
+  );
 }

--- a/libs/types/src/credit-card-company.types.ts
+++ b/libs/types/src/credit-card-company.types.ts
@@ -1,0 +1,53 @@
+/**
+ * クレジットカード会社関連の型定義
+ */
+
+/**
+ * カード会社カテゴリ
+ */
+export enum CardCompanyCategory {
+  MAJOR = 'major', // 大手カード会社
+  BANK = 'bank', // 銀行系カード
+  RETAIL = 'retail', // 流通系カード
+  ONLINE = 'online', // ネット系カード
+}
+
+/**
+ * カード会社情報
+ */
+export interface CardCompany {
+  id: string;
+  code: string; // カード会社コード
+  name: string;
+  category: CardCompanyCategory;
+  isSupported: boolean;
+}
+
+/**
+ * クレジットカード認証情報（平文）
+ */
+export interface CreditCardCredentials {
+  cardNumber: string; // カード番号（16桁）
+  cardHolderName: string; // カード名義
+  expiryDate: string; // 有効期限（YYYY-MM-DD形式）
+  username: string; // Web明細ログインID
+  password: string; // Web明細パスワード
+  apiKey?: string; // API認証キー（カード会社によって異なる）
+  [key: string]: unknown; // その他のカード会社固有の認証情報
+}
+
+/**
+ * クレジットカード接続テスト結果
+ */
+export interface CreditCardConnectionTestResult {
+  success: boolean;
+  message: string;
+  cardInfo?: {
+    cardName: string;
+    cardNumber: string; // 下4桁のみ
+    cardHolderName: string;
+    expiryDate: string;
+    issuer: string;
+  };
+  errorCode?: string;
+}

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -1,6 +1,7 @@
 export * from './transaction.types';
 export * from './institution.types';
 export * from './bank.types';
+export * from './credit-card-company.types';
 export * from './api.types';
 export * from './api/error-response';
 export * from './api/trend-analysis-response';


### PR DESCRIPTION
## 📋 概要

FR-002「クレジットカードとの連携」機能のフロントエンド実装として、クレジットカード追加画面を実装しました。

## 🎯 実装内容

### バックエンドAPI実装

- **カード会社一覧取得API** (GET /api/credit-cards/companies/supported)
  - カテゴリ別・検索対応
  - カード会社マスターデータの追加（12社）

- **クレジットカード接続テストAPI** (POST /api/credit-cards/test-connection)
  - 認証情報の検証
  - 接続テスト結果の返却

- **型定義の追加**
  - `CardCompany`, `CardCompanyCategory`
  - `CreditCardCredentials`, `CreditCardConnectionTestResult`

### フロントエンド実装

- **クレジットカード追加ページ** (`/credit-cards/add`)
  - 3ステップのウィザード形式（カード会社選択 → 認証情報入力 → 接続テスト）
  - 銀行追加画面を参考に実装

- **カード会社選択コンポーネント** (`CardCompanySelector`)
  - カテゴリ別表示（大手カード、銀行系、流通系、ネット系）
  - 検索機能

- **認証情報入力フォーム** (`CreditCardCredentialsForm`)
  - カード番号（16桁、Luhnアルゴリズム検証）
  - カード名義、有効期限
  - ログインID（メールアドレス形式）、パスワード
  - 引落日、締め日
  - API認証キー（オプション）

- **APIクライアント関数**
  - `getSupportedCardCompanies`
  - `testCreditCardConnection`

- **ConnectionTestResultコンポーネントの拡張**
  - クレジットカード接続テスト結果にも対応

## ✅ バリデーション

- カード番号: 16桁数字、Luhnアルゴリズム
- カード名義: 必須、100文字以下
- 有効期限: 必須、未来日付
- ログインID: 必須、メールアドレス形式
- パスワード: 必須、8文字以上
- 引落日・締め日: 1〜31の範囲

## 📝 注意事項

- **カード会社ごとに異なるAPI対応**: 現時点ではモック実装のため、すべてのカード会社で同一のモックアダプターを使用。実API実装時には、カード会社ごとに異なるAPIアダプターを選択する仕組みが必要（Issue #444のコメント参照）

## 🔗 関連Issue

- Issue #444: [FEATURE] FR-002: クレジットカード追加画面の実装
- Issue #420: [testing] E2Eテスト: FR-002 クレジットカードとの連携（このIssueの後に実施予定）

## ✅ チェックリスト

- [x] 実装が完了している
- [x] コードレビューが完了している
- [x] ESLint/Prettierエラーがない
- [x] TypeScript型定義が適切に設定されている
- [x] すべてのテストがパスしている
- [x] ビルドが成功している